### PR TITLE
Update GeckoView Nightly

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -48,7 +48,7 @@ def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):
         release_branch_name = "master"
 
         current_gv_version = get_current_gv_version(ac_repo, release_branch_name, channel)
-        current_gv_major_version = current_gv_version.split(".")[0]
+        current_gv_major_version = major_gv_version_from_version(current_gv_version)
         latest_gv_version = get_latest_gv_version(current_gv_major_version, channel)
 
         #
@@ -74,10 +74,9 @@ def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):
         #
 
         print(f"{ts()} Creating pull request")
-        pr = ac_repo.create_pull(title=f"GeckoView update ({channel.capitalize()}) {latest_gv_version}.",
+        pr = ac_repo.create_pull(title=f"GeckoView ({channel.capitalize()}) {latest_gv_version}",
                                  body=f"This (automated) patch updates GV {channel.capitalize()} on master to {latest_gv_version}.",
                                  head=pr_branch_name, base=release_branch_name)
-        pr.add_to_labels("🛬 needs landing")
         print(f"{ts()} Pull request at {pr.html_url}")
     except Exception as e:
         print(f"{ts()} Exception: {str(e)}")

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -37,9 +37,9 @@ def update_gv_version(ac_repo, old_gv_version, new_gv_version, branch, channel, 
                      new_content, contents.sha, branch=branch, author=author)
 
 #
-# Update GeckoView Nightly on A-C master. This is a bit of a special case since it doesn't care about
-# release branches and looks in a different Maven repo. It can probably be refactored to share more
-# code with update_geckoview() though.
+# Update GeckoView Nightly on A-C master. This is a bit of a special
+# case since it doesn't care about release branches. It can probably
+# be refactored to share more code with update_geckoview() though.
 #
 
 def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -23,7 +23,7 @@ def update_ac_version(ac_repo, old_ac_version, new_ac_version, branch, author):
 
 
 def update_gv_version(ac_repo, old_gv_version, new_gv_version, branch, channel, author):
-    if channel not in ("beta", "release"):
+    if channel not in ("nightly", "beta", "release"):
         raise Exception(f"Invalid channel {channel}")
 
     contents = ac_repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=branch)
@@ -35,6 +35,54 @@ def update_gv_version(ac_repo, old_gv_version, new_gv_version, branch, channel, 
 
     ac_repo.update_file(contents.path, f"Update GeckoView ({channel.capitalize()}) to {new_gv_version}.",
                      new_content, contents.sha, branch=branch, author=author)
+
+#
+# Update GeckoView Nightly on A-C master. This is a bit of a special case since it doesn't care about
+# release branches and looks in a different Maven repo. It can probably be refactored to share more
+# code with update_geckoview() though.
+#
+
+def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):
+    try:
+        channel = "nightly"
+        release_branch_name = "master"
+
+        current_gv_version = get_current_gv_version(ac_repo, release_branch_name, channel)
+        current_gv_major_version = current_gv_version.split(".")[0]
+        latest_gv_version = get_latest_gv_version(current_gv_major_version, channel)
+
+        #
+        # Create a new branch for this update
+        #
+
+        release_branch = ac_repo.get_branch(release_branch_name)
+        print(f"{ts()} Last commit on {release_branch_name} is {release_branch.commit.sha}")
+
+        pr_branch_name = f"GV-Nightly-{latest_gv_version}"
+        ac_repo.create_git_ref(ref=f"refs/heads/{pr_branch_name}", sha=release_branch.commit.sha)
+        print(f"{ts()} Created branch {pr_branch_name} on {release_branch.commit.sha}")
+
+        #
+        # Update buildSrc/src/main/java/Gecko.kt
+        #
+
+        print(f"{ts()} Updating buildSrc/src/main/java/Gecko.kt")
+        update_gv_version(ac_repo, current_gv_version, latest_gv_version, pr_branch_name, channel, author)
+
+        #
+        # Create the pull request
+        #
+
+        print(f"{ts()} Creating pull request")
+        pr = ac_repo.create_pull(title=f"GeckoView update ({channel.capitalize()}) {latest_gv_version}.",
+                                 body=f"This (automated) patch updates GV {channel.capitalize()} on master to {latest_gv_version}.",
+                                 head=pr_branch_name, base=release_branch_name)
+        pr.add_to_labels("🛬 needs landing")
+        print(f"{ts()} Pull request at {pr.html_url}")
+    except Exception as e:
+        print(f"{ts()} Exception: {str(e)}")
+        raise e
+        # TODO Clean up the mess
 
 
 #

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -40,7 +40,9 @@ def main(argv, ac_repo, fenix_repo, author, debug=False):
 
     # Android Components
     if argv[1] == "android-components":
-        if argv[2] == "update-geckoview-beta":
+        if argv[2] == "update-geckoview-nightly":
+            android_components.update_geckoview_nightly(ac_repo, fenix_repo, author, debug)
+        elif argv[2] == "update-geckoview-beta":
             android_components.update_geckoview(ac_repo, fenix_repo, "beta", author, debug)
         elif argv[2] == "update-geckoview-release":
             android_components.update_geckoview(ac_repo, fenix_repo, "release", author, debug)

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -108,6 +108,25 @@ def test_validate_ac_version_bad():
         validate_ac_version("63.0-beta.2")
 
 
+def test_major_gv_version_from_version_bad():
+    with pytest.raises(Exception):
+        major_gv_version_from_version("")
+    with pytest.raises(Exception):
+        major_gv_version_from_version("lol")
+    with pytest.raises(Exception):
+        major_gv_version_from_version("81")
+    with pytest.raises(Exception):
+        major_gv_version_from_version("81.0")
+    with pytest.raises(Exception):
+        major_gv_version_from_version("81.0.20201012")
+    with pytest.raises(Exception):
+        major_gv_version_from_version("81.0.202010121122")
+
+def test_major_gv_version_from_version_good():
+    assert major_gv_version_from_version("81.0.20201012085804") == "81"
+    assert major_gv_version_from_version("123.0.20231012085804") == "123"
+
+
 def test_validate_ac_version_good():
     assert validate_ac_version("64.0.20201027143116") == "64.0.20201027143116"
     assert validate_ac_version("63.0.0") == "63.0.0"

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -46,6 +46,7 @@ def test_match_gv_version():
 
 def test_get_current_gv_version():
     repo = github.Github().get_repo(f"st3fan/android-components")
+    assert get_current_gv_version(repo, "master", "nightly") == "85.0.20201120094511"
     assert get_current_gv_version(repo, "releases/57.0", "beta") == "81.0.20200910180444"
     assert get_current_gv_version(repo, "releases/57.0", "release") == "81.0.20201012085804"
 
@@ -116,7 +117,7 @@ def test_validate_ac_version_good():
 
 
 def test_get_latest_gv_version_release():
-    assert get_latest_gv_version(81, "release") == "81.0.20201012085804"
+    assert get_latest_gv_version(81, "release") == "81.0.20201108175212"
 
 
 def test_get_latest_gv_version_beta():
@@ -186,7 +187,7 @@ def test_compare_gv_versions():
 
 def test_get_latest_ac_version():
     assert get_latest_ac_version(56) == "56.0.0"
-    assert get_latest_ac_version(57) == "57.0.8"
+    assert get_latest_ac_version(57) == "57.0.9"
     assert get_latest_ac_version(58) == "58.0.0"
     assert get_latest_ac_version(59) == "59.0.0"
-    assert get_latest_ac_version(60) == "60.0.7"
+    assert get_latest_ac_version(60) == "60.0.8"

--- a/src/util.py
+++ b/src/util.py
@@ -63,7 +63,7 @@ def get_current_ac_version_in_fenix(fenix_repo, release_branch_name):
 
 def match_gv_version(src, channel):
     """Find the GeckoView Beta version in the contents of the given AndroidComponents.kt file."""
-    if channel not in ("beta", "release"):
+    if channel not in ("nightly", "beta", "release"):
         raise Exception(f"Invalid channel {channel}")
     if match := re.compile(fr'{channel}_version = "([^"]*)"', re.MULTILINE).search(src):
         return validate_gv_version(match[1])
@@ -72,7 +72,7 @@ def match_gv_version(src, channel):
 
 def get_current_gv_version(repo, release_branch_name, channel):
     """Return the current gv beta version used on the given release branch"""
-    if channel not in ("beta", "release"):
+    if channel not in ("nightly", "beta", "release"):
         raise Exception(f"Invalid channel {channel}")
     content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
     return match_gv_version(content_file.decoded_content.decode('utf8'), channel)
@@ -92,7 +92,7 @@ MAVEN = "https://maven.mozilla.org/maven2"
 
 def get_latest_gv_version(gv_major_version, channel):
     """Find the last geckoview beta release version on Maven for the given major version"""
-    if channel not in ("beta", "release"):
+    if channel not in ("nightly", "beta", "release"):
         raise Exception(f"Invalid channel {channel}")
 
     # Find the latest release in the multi-arch .aar

--- a/src/util.py
+++ b/src/util.py
@@ -48,6 +48,10 @@ def validate_gv_version(v):
         raise Exception(f"Invalid GV version {v}")
     return v
 
+def major_gv_version_from_version(v):
+    """Return the major version for the given GV version"""
+    c = validate_gv_version(v).split(".")
+    return c[0]
 
 def match_ac_version_in_fenix(src):
     if match := re.compile(r'VERSION = "([^"]*)"', re.MULTILINE).search(src):


### PR DESCRIPTION
This PR adds a `update-geckoview-nightly` command to `android-components`.

It will look on `master` to find out what the current major version of GV is and then look in Maven to find out if there is a newer Nightly release available. If there is then it prepares a PR that updates `buildSrc/src/main/java/Gecko.kt`.
