### PR TITLE
Fixes #6 - Update the Reference Browser with A-C Nightly

### DIFF
--- a/src/reference_browser.py
+++ b/src/reference_browser.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+
+from util import *
+
+
+def _update_ac_version(rb_repo, branch, old_ac_version, new_ac_version, author):
+    contents = rb_repo.get_contents("buildSrc/src/main/java/AndroidComponents.kt", ref=branch)
+    content = contents.decoded_content.decode("utf-8")
+    new_content = content.replace(f'VERSION = "{old_ac_version}"', f'VERSION = "{new_ac_version}"')
+    if content == new_content:
+        raise Exception("Update to AndroidComponents.kt resulted in no changes: maybe the file was already up to date?")
+    rb_repo.update_file(contents.path, f"Update to Android-Components {new_ac_version}.",
+                        new_content, contents.sha, branch=branch, author=author)
+
+
+def update_android_components(ac_repo, rb_repo, author, debug):
+    release_branch_name = "master" # RB Only has master
+
+    current_ac_version = get_current_ac_version_in_reference_browser(rb_repo, release_branch_name)
+    print(f"{ts()} Current A-C version in R-B is {current_ac_version}")
+
+    ac_major_version = major_ac_version_from_version(current_ac_version)
+
+    latest_ac_nightly_version = get_latest_ac_nightly_version()
+
+    if compare_ac_versions(current_ac_version, latest_ac_nightly_version) >= 0:
+        print(f"{ts()} No need to upgrade; Reference-Browser is on A-C {current_ac_version}")
+        return
+
+    print(f"{ts()} We should upgrade Reference Browser to Android-Components {latest_ac_nightly_version}")
+
+    pr_branch_name = f"relbot/AC-Nightly-{latest_ac_nightly_version}"
+
+    try:
+        if pr_branch := rb_repo.get_branch(pr_branch_name):
+            print(f"{ts()} The PR branch {pr_branch_name} already exists. Exiting.")
+            return
+    except GithubException as e:
+        pass
+
+    release_branch = rb_repo.get_branch(release_branch_name)
+    print(f"{ts()} Last commit on {release_branch_name} is {release_branch.commit.sha}")
+
+    print(f"{ts()} Creating branch {pr_branch_name} on {release_branch.commit.sha}")
+    rb_repo.create_git_ref(ref=f"refs/heads/{pr_branch_name}", sha=release_branch.commit.sha)
+
+    print(f"{ts()} Updating AndroidComponents.kt from {current_ac_version} to {latest_ac_nightly_version} on {pr_branch_name}")
+    _update_ac_version(rb_repo, pr_branch_name, current_ac_version, latest_ac_nightly_version, author)
+
+    print(f"{ts()} Creating pull request")
+    pr = rb_repo.create_pull(title=f"Update to Android-Components {latest_ac_nightly_version}.",
+                                body=f"This (automated) patch updates Android-Components to {latest_ac_nightly_version}.",
+                                head=pr_branch_name, base=release_branch_name)
+    print(f"{ts()} Pull request at {pr.html_url}")

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -25,7 +25,7 @@ import os, sys
 
 from github import Github, InputGitAuthor, enable_console_debug_logging
 
-import android_components, fenix
+import android_components, fenix, reference_browser
 
 
 DEFAULT_ORGANIZATION = "st3fan"
@@ -33,9 +33,9 @@ DEFAULT_AUTHOR_NAME = "Stefan Arentz"
 DEFAULT_AUTHOR_EMAIL = "stefan@arentz.ca"
 
 
-def main(argv, ac_repo, fenix_repo, author, debug=False):
+def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False):
     if len(argv) < 2:
-        print("usage: relbot <android-components|fenix> command...")
+        print("usage: relbot <android-components|reference-browser|fenix> command...")
         sys.exit(1)
 
     # Android Components
@@ -49,7 +49,15 @@ def main(argv, ac_repo, fenix_repo, author, debug=False):
         elif argv[2] == "create-release":
             android_components.create_release(ac_repo, fenix_repo, author, debug)
         else:
-            print("usage: relbot android-components <update-geckoview-beta|update-geckoview-release|create-release>")
+            print("usage: relbot android-components <update-geckoview-{nighty,beta}|update-geckoview-release|create-release>")
+            sys.exit(1)
+
+    # Reference Browser
+    if argv[1] == "reference-browser":
+        if argv[2] == "update-android-components":
+            reference_browser.update_android_components(ac_repo, rb_repo, author, debug)
+        else:
+            print("usage: relbot fenix <update-android-components>")
             sys.exit(1)
 
     # Fenix
@@ -86,6 +94,7 @@ if __name__ == "__main__":
     organization = os.getenv("GITHUB_REPOSITORY_OWNER") or DEFAULT_ORGANIZATION
 
     ac_repo = github.get_repo(f"{organization}/android-components")
+    rb_repo = github.get_repo(f"{organization}/reference-browser")
     fenix_repo = github.get_repo(f"{organization}/fenix")
 
     author_name = os.getenv("AUTHOR_NAME") or DEFAULT_AUTHOR_NAME
@@ -94,4 +103,4 @@ if __name__ == "__main__":
 
     print(f"This is relbot working on https://github.com/{organization} as {author_email} / {author_name}")
 
-    main(sys.argv, ac_repo, fenix_repo, author, debug)
+    main(sys.argv, ac_repo, rb_repo, fenix_repo, author, debug)

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -57,7 +57,7 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False):
         if argv[2] == "update-android-components":
             reference_browser.update_android_components(ac_repo, rb_repo, author, debug)
         else:
-            print("usage: relbot fenix <update-android-components>")
+            print("usage: relbot reference-browser <update-android-components>")
             sys.exit(1)
 
     # Fenix

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -65,9 +65,28 @@ def test_match_ac_version_in_fenix():
     assert match_ac_version_in_fenix(ANDROID_COMPONENTS_KT) == "64.0.20201027143116"
 
 
+RB_ANDROID_COMPONENTS_KT = """
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+object AndroidComponents {
+    const val VERSION = "69.0.20201203202830"
+}
+"""
+
+def test_match_ac_version_in_reference_browser():
+    assert match_ac_version_in_reference_browser(RB_ANDROID_COMPONENTS_KT) == "69.0.20201203202830"
+
+
 def test_get_current_ac_version_in_fenix():
     repo = github.Github().get_repo(f"st3fan/fenix")
     assert get_current_ac_version_in_fenix(repo, "releases/v82.0.0") == "60.0.5"
+
+
+def test_get_current_ac_version_in_reference_browser():
+    repo = github.Github().get_repo(f"st3fan/reference-browser")
+    assert get_current_ac_version_in_fenix(repo, "for-relbot-tests") == "69.0.20201203202830"
 
 
 def test_get_current_ac_version():
@@ -133,6 +152,26 @@ def test_validate_ac_version_good():
     assert validate_ac_version("63.0.1") == "63.0.1"
     assert validate_ac_version("63.1.2") == "63.1.2"
     assert validate_ac_version("12.34.56") == "12.34.56"
+
+
+def test_major_ac_version_from_version_bad():
+    with pytest.raises(Exception):
+        major_ac_version_from_version("")
+    with pytest.raises(Exception):
+        major_ac_version_from_version("lol")
+    with pytest.raises(Exception):
+        major_ac_version_from_version("63")
+    with pytest.raises(Exception):
+        major_ac_version_from_version("63.0")
+    with pytest.raises(Exception):
+        major_ac_version_from_version("63.0-beta.2")
+
+
+def test_major_ac_version_from_version_good():
+    assert major_ac_version_from_version("63.0.0") == "63"
+    assert major_ac_version_from_version("64.0.1") == "64"
+    assert major_ac_version_from_version("65.1.2") == "65"
+    assert major_ac_version_from_version("123.0.8") == "123"
 
 
 def test_get_latest_gv_version_release():
@@ -210,3 +249,7 @@ def test_get_latest_ac_version():
     assert get_latest_ac_version(58) == "58.0.0"
     assert get_latest_ac_version(59) == "59.0.0"
     assert get_latest_ac_version(60) == "60.0.8"
+
+def test_get_latest_ac_nightly_version():
+    assert get_latest_ac_nightly_version() is not None
+

--- a/src/util.py
+++ b/src/util.py
@@ -42,6 +42,12 @@ def validate_ac_version(v):
     return v
 
 
+def major_ac_version_from_version(v):
+    """Return the major version for the given AC version"""
+    c = validate_ac_version(v).split(".")
+    return c[0]
+
+
 def validate_gv_version(v):
     """Validate that v is in the format of 82.0.20201027185343. Returns v or raises an exception."""
     if not re.match(r"^\d{2,}\.\d\.\d{14}$", v):
@@ -63,6 +69,17 @@ def get_current_ac_version_in_fenix(fenix_repo, release_branch_name):
     """Return the current A-C version used on the given Fenix branch"""
     content_file = fenix_repo.get_contents("buildSrc/src/main/java/AndroidComponents.kt", ref=release_branch_name)
     return match_ac_version_in_fenix(content_file.decoded_content.decode('utf8'))
+
+
+def match_ac_version_in_reference_browser(src):
+    if match := re.compile(r'VERSION = "([^"]*)"', re.MULTILINE).search(src):
+        return validate_ac_version(match[1])
+    raise Exception(f"Could not match the VERSION in AndroidComponents.kt")
+
+def get_current_ac_version_in_reference_browser(rb_repo, release_branch_name):
+    """Return the current A-C version used on the given branch"""
+    content_file = rb_repo.get_contents("buildSrc/src/main/java/AndroidComponents.kt", ref=release_branch_name)
+    return match_ac_version_in_reference_browser(content_file.decoded_content.decode('utf8'))
 
 
 def match_gv_version(src, channel):
@@ -145,6 +162,14 @@ def get_latest_ac_version(ac_major_version):
 
     versions = sorted(versions)
     return versions[-1]
+
+
+def get_latest_ac_nightly_version():
+    """Find the last android-components Nightly release on Maven for the given major version"""
+    r = requests.get("https://nightly.maven.mozilla.org/maven2/org/mozilla/components/ui-widgets/maven-metadata.xml")
+    r.raise_for_status()
+    metadata = xmltodict.parse(r.text)
+    return metadata['metadata']['versioning']['latest']
 
 
 def get_next_ac_version(current_version):


### PR DESCRIPTION
This patch adds a `reference-browser update-android-components` command that creates a PR to update the Reference Browser to the latest Android Components Nightly release.