### PR TITLE
Fixes #9 - A-C Update-GeckoView-Nightly task throws an exception

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -80,7 +80,6 @@ def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):
         print(f"{ts()} Pull request at {pr.html_url}")
     except Exception as e:
         print(f"{ts()} Exception: {str(e)}")
-        raise e
         # TODO Clean up the mess
 
 


### PR DESCRIPTION
This removes a `raise` in the `catch` block. I think this was left in from debugging something. Without re-raising an error or unexpected state will simply result in a gentle abort.