### PR TITLE
Better sorting and reporting of A-C and GV versions

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -48,8 +48,11 @@ def update_geckoview_nightly(ac_repo, fenix_repo, author, debug):
         release_branch_name = "master"
 
         current_gv_version = get_current_gv_version(ac_repo, release_branch_name, channel)
+        print(f"{ts()} Current GV {channel.capitalize()} version in A-C is {current_gv_version}")
+
         current_gv_major_version = major_gv_version_from_version(current_gv_version)
         latest_gv_version = get_latest_gv_version(current_gv_major_version, channel)
+        print(f"{ts()} Latest GV {channel.capitalize()} version available is {latest_gv_version}")
 
         if compare_gv_versions(current_gv_version, latest_gv_version) >= 0:
             print(f"{ts()} No newer GV {channel.capitalize()} release found. Exiting.")
@@ -112,9 +115,14 @@ def update_geckoview(ac_repo, fenix_repo, channel, author, debug):
         ac_major_version = discover_ac_major_version(ac_repo)
         gv_major_version = discover_gv_major_version()
         release_branch_name = f"releases/{ac_major_version}.0"
+
         current_ac_version = get_current_ac_version(ac_repo, release_branch_name)
+
         current_gv_version = get_current_gv_version(ac_repo, release_branch_name, channel)
+        print(f"{ts()} Current GV {channel.capitalize()} version in A-C {current_ac_version} is {current_gv_version}")
+
         latest_gv_version = get_latest_gv_version(gv_major_version, channel)
+        print(f"{ts()} Latest GV {channel.capitalize()} version available is {latest_gv_version}")
 
         if not latest_gv_version.startswith(f"{gv_major_version}."):
             raise Exception(f"Latest GV {channel.capitalize()} is not same major release. Exiting.")

--- a/src/fenix.py
+++ b/src/fenix.py
@@ -29,16 +29,11 @@ def update_android_components(ac_repo, fenix_repo, author, debug):
         print(f"{ts()} Looking at Fenix {channel.capitalize()} on {release_branch_name}")
 
         current_ac_version = get_current_ac_version_in_fenix(fenix_repo, release_branch_name)
-        print(f"{ts()} Current A-C version is {current_ac_version}")
+        print(f"{ts()} Current A-C version in Fenix is {current_ac_version}")
 
         ac_major_version = int(current_ac_version[0:2]) # TODO Util & Test!
         latest_ac_version = get_latest_ac_version(ac_major_version)
-
-        print(current_ac_version)
-
-        # For testing on st3fan/fenix
-        #if channel == "beta":
-        #    latest_ac_version = "67.0.2"
+        print(f"{ts()} Latest A-C version available is {latest_ac_version}")
 
         if len(current_ac_version) != 19 and compare_ac_versions(current_ac_version, latest_ac_version) >= 0:
             print(f"{ts()} No need to upgrade; Fenix {channel.capitalize()} is on A-C {current_ac_version}")

--- a/src/util.py
+++ b/src/util.py
@@ -116,7 +116,7 @@ def get_latest_gv_version(gv_major_version, channel):
     if len(versions) == 0:
         raise Exception(f"Could not find any GeckoView {channel.capitalize()} {gv_major_version} releases")
 
-    versions = sorted(versions)
+    versions = sorted(versions, key=gv_version_sort_key)
     latest = versions[-1]
 
     # Make sure this release has been uploaded for all architectures.
@@ -143,7 +143,7 @@ def get_latest_ac_version(ac_major_version):
     if len(versions) == 0:
         raise Exception(f"Could not find any Android-Components {ac_major_version} releases on maven.mozilla.org")
 
-    versions = sorted(versions)
+    versions = sorted(versions, key=ac_version_sort_key)
     return versions[-1]
 
 
@@ -184,3 +184,11 @@ def compare_gv_versions(a, b):
     b = b.split(".")
     b = int(b[0])*10000000000000000000 + int(b[1])*1000000000000000 + int(b[2])
     return a-b
+
+def ac_version_sort_key(a):
+    a = a.split(".")
+    return int(a[0])*1000000 + int(a[1])*1000 + int(a[2])
+
+def gv_version_sort_key(a):
+    a = a.split(".")
+    return int(a[0])*10000000000000000000 + int(a[1])*1000000000000000 + int(a[2])


### PR DESCRIPTION
This patch sorts maven versions semantically and not alphabetically. It also adds a little more reporting on versions found and used.

```
2020-12-08 13:55:20.972563 Current GV Beta version in A-C 67.0.10 is 84.0.20201206192040
2020-12-08 13:55:21.391837 Latest GV Beta version available is 84.0.20201206192040
2020-12-08 13:55:21.391897 No newer GV Beta release found. Exiting.
```

```
2020-12-08 13:57:42.802597 Looking at Fenix Beta on releases/v84.0.0
2020-12-08 13:57:42.910436 Current A-C version in Fenix is 67.0.9
2020-12-08 13:57:43.057411 Latest A-C version available is 67.0.10
```

This makes it easier to follow what is going on.