### PR TITLE
Do not raise an exception if the PR branch already exists

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -46,7 +46,8 @@ def update_android_components(ac_repo, fenix_repo, author, debug):
         try:
             pr_branch = fenix_repo.get_branch(pr_branch_name)
             if pr_branch:
-                raise Exception(f"The PR branch {pr_branch_name} already exists. Exiting.")
+                print(f"{ts()} The PR branch {pr_branch_name} already exists. Exiting.")
+                continue
         except GithubException as e:
             pass
 


### PR DESCRIPTION
This patch simply prints a warning and then continues with the next channel if the PR branch was already created. (Which can happen if the script runs before the PR landed). This is nicer and shows less scary noise in the log.

Before:

```
2020-12-08 14:03:13.919428 Looking at Fenix Beta on releases/v84.0.0
2020-12-08 14:03:14.107040 Current A-C version in Fenix is 67.0.9
2020-12-08 14:03:14.221268 Latest A-C version available is 67.0.10
2020-12-08 14:03:14.221308 We should upgrade Fenix 84 Beta to Android-Components 67.0.10
Traceback (most recent call last):
  File "relbot.py", line 97, in <module>
    main(sys.argv, ac_repo, fenix_repo, author, debug)
  File "relbot.py", line 58, in main
    fenix.update_android_components(ac_repo, fenix_repo, author, debug)
  File "/Users/stefan/Mozilla/relbot/src/fenix.py", line 49, in update_android_components
    raise Exception(f"The PR branch {pr_branch_name} already exists. Exiting.")
Exception: The PR branch relbot/AC-67.0.10 already exists. Exiting.
```

(This actually is a bug since it breaks out of the channel loop, skipping release)

After:

```
2020-12-08 14:04:11.363912 Looking at Fenix Beta on releases/v84.0.0
2020-12-08 14:04:11.519878 Current A-C version in Fenix is 67.0.9
2020-12-08 14:04:11.619436 Latest A-C version available is 67.0.10
2020-12-08 14:04:11.619479 We should upgrade Fenix 84 Beta to Android-Components 67.0.10
2020-12-08 14:04:11.759701 The PR branch relbot/AC-67.0.10 already exists. Exiting.
2020-12-08 14:04:11.759743 Looking at Fenix Release on releases/v83.0.0
2020-12-08 14:04:11.884235 Current A-C version in Fenix is 63.0.9
2020-12-08 14:04:11.956043 Latest A-C version available is 63.0.9
2020-12-08 14:04:11.956096 No need to upgrade; Fenix Release is on A-C 63.0.9
```
