### PR TITLE
Fixes #3 - Tests should use a GitHub token

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,5 +26,7 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pytest

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -3,10 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 
+import os
+
 import github
 import pytest
 
 from util import *
+
+
+@pytest.fixture
+def gh():
+    return github.Github(os.getenv("GITHUB_TOKEN"))
 
 
 GECKO_KT = """
@@ -44,8 +51,8 @@ def test_match_gv_version():
     assert match_gv_version(GECKO_KT, "beta") == "81.0.20200910180444"
 
 
-def test_get_current_gv_version():
-    repo = github.Github().get_repo(f"st3fan/android-components")
+def test_get_current_gv_version(gh):
+    repo = gh.get_repo(f"st3fan/android-components")
     assert get_current_gv_version(repo, "master", "nightly") == "85.0.20201120094511"
     assert get_current_gv_version(repo, "releases/57.0", "beta") == "81.0.20200910180444"
     assert get_current_gv_version(repo, "releases/57.0", "release") == "81.0.20201012085804"
@@ -79,18 +86,18 @@ def test_match_ac_version_in_reference_browser():
     assert match_ac_version_in_reference_browser(RB_ANDROID_COMPONENTS_KT) == "69.0.20201203202830"
 
 
-def test_get_current_ac_version_in_fenix():
-    repo = github.Github().get_repo(f"st3fan/fenix")
+def test_get_current_ac_version_in_fenix(gh):
+    repo = gh.get_repo(f"st3fan/fenix")
     assert get_current_ac_version_in_fenix(repo, "releases/v82.0.0") == "60.0.5"
 
 
-def test_get_current_ac_version_in_reference_browser():
-    repo = github.Github().get_repo(f"st3fan/reference-browser")
+def test_get_current_ac_version_in_reference_browser(gh):
+    repo = gh.get_repo(f"st3fan/reference-browser")
     assert get_current_ac_version_in_fenix(repo, "for-relbot-tests") == "69.0.20201203202830"
 
 
-def test_get_current_ac_version():
-    repo = github.Github().get_repo(f"st3fan/android-components")
+def test_get_current_ac_version(gh):
+    repo = gh.get_repo(f"st3fan/android-components")
     assert get_current_ac_version(repo, "releases/57.0") == "57.0.8"
 
 
@@ -217,11 +224,11 @@ def test_ac_version_from_tag_bad():
         ac_version_from_tag("63.0-beta.2")
 
 
-def test_get_recent_ac_releases():
+def test_get_recent_ac_releases(gh):
     # No releases on the test repo
-    assert get_recent_ac_releases(github.Github().get_repo(f"st3fan/android-components")) == []
+    assert get_recent_ac_releases(gh.get_repo(f"st3fan/android-components")) == []
     # But plenty releases on the actual repo
-    assert get_recent_ac_releases(github.Github().get_repo(f"mozilla-mobile/android-components")) != []
+    assert get_recent_ac_releases(gh.get_repo(f"mozilla-mobile/android-components")) != []
 
 
 def test_compare_ac_versions():


### PR DESCRIPTION
This patch replaces invocations of `github.Github()` with a test fixture that creates the GitHub client from the `GITHUB_TOKEN` environment variable. It also updates the `python-app.yml` workflow to pass the temporary token that Actions get to _PyTest_.

This will help with rate limits on the GitHub API.