### PR TITLE
Fixes #11 - A-C Create-Release falls through to usage

### DIFF
--- a/src/relbot.py
+++ b/src/relbot.py
@@ -53,7 +53,7 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False):
             sys.exit(1)
 
     # Reference Browser
-    if argv[1] == "reference-browser":
+    elif argv[1] == "reference-browser":
         if argv[2] == "update-android-components":
             reference_browser.update_android_components(ac_repo, rb_repo, author, debug)
         else:


### PR DESCRIPTION
This patch fixes an `if` to an `elif` that was accidentally falling through and resulting in an incorrect error.