### PR TITLE
Fixes #23 - Discover relevant Fenix releases

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -21,53 +21,63 @@ def _update_ac_version(fenix_repo, branch, old_ac_version, new_ac_version, autho
 # a newer android-components that can be pulled in.
 #
 
+def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version, author, debug):
+    print(f"{ts()} Looking at Fenix {fenix_major_version}")
+
+    # Make sure the release branch for this version exists
+    release_branch_name = f"releases/v{fenix_major_version}.0.0"
+    release_branch = fenix_repo.get_branch(release_branch_name)
+
+    print(f"{ts()} Looking at Fenix {fenix_major_version} on {release_branch_name}")
+
+    current_ac_version = get_current_ac_version_in_fenix(fenix_repo, release_branch_name)
+    print(f"{ts()} Current A-C version in Fenix is {current_ac_version}")
+
+    ac_major_version = int(current_ac_version[0:2]) # TODO Util & Test!
+    latest_ac_version = get_latest_ac_version(ac_major_version)
+    print(f"{ts()} Latest A-C version available is {latest_ac_version}")
+
+    if len(current_ac_version) != 19 and compare_ac_versions(current_ac_version, latest_ac_version) >= 0:
+        print(f"{ts()} No need to upgrade; Fenix {fenix_major_version} is on A-C {current_ac_version}")
+        return
+
+    print(f"{ts()} We are going to upgrade Fenix {fenix_major_version} to Android-Components {latest_ac_version}")
+
+    # Create a PR branch name that is likely not to conflict with anything else
+    pr_branch_name = f"relbot/update-android-components/Fenix-{fenix_major_version}/AC-{latest_ac_version}"
+
+    try:
+        pr_branch = fenix_repo.get_branch(pr_branch_name)
+        if pr_branch:
+            print(f"{ts()} The PR branch {pr_branch_name} already exists. Exiting.")
+            return
+    except GithubException as e:
+        # TODO Only ignore a 404 here, fail on others
+        pass
+
+    print(f"{ts()} Last commit on {release_branch_name} is {release_branch.commit.sha}")
+
+    print(f"{ts()} Creating branch {pr_branch_name} on {release_branch.commit.sha}")
+    fenix_repo.create_git_ref(ref=f"refs/heads/{pr_branch_name}", sha=release_branch.commit.sha)
+
+    print(f"{ts()} Updating AndroidComponents.kt from {current_ac_version} to {latest_ac_version} on {pr_branch_name}")
+    _update_ac_version(fenix_repo, pr_branch_name, current_ac_version, latest_ac_version, author)
+
+    print(f"{ts()} Creating pull request")
+    pr = fenix_repo.create_pull(title=f"Update to Android-Components {latest_ac_version}.",
+                             body=f"This (automated) patch updates Android-Components to {latest_ac_version}.",
+                             head=pr_branch_name, base=release_branch_name)
+    pr.add_to_labels("needs:review")
+    pr.add_to_labels("pr:needs-landing")
+    print(f"{ts()} Pull request at {pr.html_url}")
+
+
 def update_android_components(ac_repo, fenix_repo, author, debug):
-    for channel in ("beta", "release"):
-        fenix_major_version = discover_fenix_major_version(channel)
-        release_branch_name = f"releases/v{fenix_major_version}.0.0"
-
-        print(f"{ts()} Looking at Fenix {channel.capitalize()} on {release_branch_name}")
-
-        current_ac_version = get_current_ac_version_in_fenix(fenix_repo, release_branch_name)
-        print(f"{ts()} Current A-C version in Fenix is {current_ac_version}")
-
-        ac_major_version = int(current_ac_version[0:2]) # TODO Util & Test!
-        latest_ac_version = get_latest_ac_version(ac_major_version)
-        print(f"{ts()} Latest A-C version available is {latest_ac_version}")
-
-        if len(current_ac_version) != 19 and compare_ac_versions(current_ac_version, latest_ac_version) >= 0:
-            print(f"{ts()} No need to upgrade; Fenix {channel.capitalize()} is on A-C {current_ac_version}")
-            continue
-
-        print(f"{ts()} We should upgrade Fenix {fenix_major_version} {channel.capitalize()} to Android-Components {latest_ac_version}")
-
-        pr_branch_name = f"relbot/AC-{latest_ac_version}"
-
+    for fenix_version in get_recent_fenix_versions(fenix_repo):
         try:
-            pr_branch = fenix_repo.get_branch(pr_branch_name)
-            if pr_branch:
-                print(f"{ts()} The PR branch {pr_branch_name} already exists. Exiting.")
-                continue
-        except GithubException as e:
-            pass
-
-        release_branch = fenix_repo.get_branch(release_branch_name)
-        print(f"{ts()} Last commit on {release_branch_name} is {release_branch.commit.sha}")
-
-        print(f"{ts()} Creating branch {pr_branch_name} on {release_branch.commit.sha}")
-        fenix_repo.create_git_ref(ref=f"refs/heads/{pr_branch_name}", sha=release_branch.commit.sha)
-
-        print(f"{ts()} Updating AndroidComponents.kt from {current_ac_version} to {latest_ac_version} on {pr_branch_name}")
-        _update_ac_version(fenix_repo, pr_branch_name, current_ac_version, latest_ac_version, author)
-
-        print(f"{ts()} Creating pull request")
-        pr = fenix_repo.create_pull(title=f"Update to Android-Components {latest_ac_version}.",
-                                 body=f"This (automated) patch updates Android-Components to {latest_ac_version}.",
-                                 head=pr_branch_name, base=release_branch_name)
-        pr.add_to_labels("needs:review")
-        pr.add_to_labels("pr:needs-landing")
-        print(f"{ts()} Pull request at {pr.html_url}")
-
+            update_android_components_in_fenix(ac_repo, fenix_repo, fenix_version, author, debug)
+        except Exception as e:
+            print(f"{ts()} Failed to update A-C in Fenix {fenix_version}: {str(e)}")
 
 
 def create_release(ac_repo, fenix_repo, author, debug):

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -260,3 +260,19 @@ def test_get_latest_ac_version():
 def test_get_latest_ac_nightly_version():
     assert get_latest_ac_nightly_version() is not None
 
+
+def test_get_fenix_release_branches(gh):
+    assert get_fenix_release_branches(gh.get_repo(f"st3fan/fenix")) == ["releases/v79.0.0", "releases/v82.0.0", "releases/v83.0.0"]
+
+def test_major_version_from_fenix_release_branch_name():
+    assert major_version_from_fenix_release_branch_name("releases/v79.0.0") == 79
+    assert major_version_from_fenix_release_branch_name("releases/v83.0.0") == 83
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases/v83.1.0")
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases/Cheese")
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases/v84.0.0-beta.1")
+
+def test_get_recent_fenix_versions(gh):
+    assert get_recent_fenix_versions(gh.get_repo(f"st3fan/fenix")) == [82, 83]

--- a/src/util.py
+++ b/src/util.py
@@ -15,17 +15,6 @@ import xmltodict
 AC_MAJOR_VERSION = 67 # TODO This should be discovered dynamically
 GV_MAJOR_VERSION = 84 # TODO This should be discovered dynamically
 
-FENIX_MAJOR_RELEASE_VERSION = 83 # TODO This should be discovered dynamically
-FENIX_MAJOR_BETA_VERSION = 84 # TODO This should be discovered dynamically
-
-
-def discover_fenix_major_version(channel):
-    if channel not in ("beta", "release"):
-        raise Exception(f"Invalid channel {channel}")
-    # TODO This should be discovered dynamically
-    versions = { "beta": FENIX_MAJOR_BETA_VERSION, "release": FENIX_MAJOR_RELEASE_VERSION }
-    return versions[channel]
-
 
 def discover_ac_major_version(repo):
     return AC_MAJOR_VERSION # TODO This should be discovered dynamically

--- a/src/util.py
+++ b/src/util.py
@@ -217,3 +217,19 @@ def ac_version_sort_key(a):
 def gv_version_sort_key(a):
     a = a.split(".")
     return int(a[0])*10000000000000000000 + int(a[1])*1000000000000000 + int(a[2])
+
+
+def get_fenix_release_branches(repo):
+    return [branch.name for branch in repo.get_branches() if re.match(r"^releases/v\d+\.0\.0$", branch.name)]
+
+
+def major_version_from_fenix_release_branch_name(branch_name):
+    if matches := re.match(r"^releases/v(\d+)\.0\.0$", branch_name):
+        return int(matches[1])
+    raise Exception(f"Unexpected release branch name: {branch_name}")
+
+
+def get_recent_fenix_versions(repo):
+    major_fenix_versions = [major_version_from_fenix_release_branch_name(branch_name)
+                            for branch_name in get_fenix_release_branches(repo)]
+    return sorted(major_fenix_versions, reverse=False)[-2:]


### PR DESCRIPTION
This patch moves away from using _channels_ for updating Fenix and simply looks at the two most recent versions for which release branches exist.

This means we can remove the hard-coded `FENIX_MAJOR_RELEASE_VERSION` and `FENIX_MAJOR_BETA_VERSION` constants and that we do not have to update anything manually.

The discovery code is pretty strict about the branches it considers - they must be in the `releases/vXX.0.0` format. Anything else will be ignored.