### PR TITLE
Fixes #36 - Update GeckoView in all relevant A-C releases

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -149,6 +149,23 @@ def update_master(ac_repo, fenix_repo, author, debug, dry_run):
         except Exception as e:
             print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
 
+#
+# Update GeckoView Release and Beta in all "relevant" A-C releases.
+#
+
+def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
+    for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
+        try:
+            _update_geckoview(ac_repo, fenix_repo, "release", ac_version, author, debug, dry_run)
+        except Exception as e:
+            print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
+
+        try:
+            _update_geckoview(ac_repo, fenix_repo, "beta", ac_version, author, debug, dry_run)
+        except Exception as e:
+            print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
+
+
 
 #
 # Update GeckoView Beta in the currently most recent A-C release. This

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -147,7 +147,7 @@ def update_master(ac_repo, fenix_repo, author, debug, dry_run):
         try:
             _update_geckoview(ac_repo, fenix_repo, gv_channel, None, author, debug, dry_run)
         except Exception as e:
-            print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
+            print(f"{ts()} Exception while updating GeckoView {gv_channel.capitalize()} on A-C master: {str(e)}")
 
 #
 # Update GeckoView Release and Beta in all "relevant" A-C releases.
@@ -155,16 +155,11 @@ def update_master(ac_repo, fenix_repo, author, debug, dry_run):
 
 def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
     for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
-        try:
-            _update_geckoview(ac_repo, fenix_repo, "release", ac_version, author, debug, dry_run)
-        except Exception as e:
-            print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
-
-        try:
-            _update_geckoview(ac_repo, fenix_repo, "beta", ac_version, author, debug, dry_run)
-        except Exception as e:
-            print(f"{ts()} Exception while updating GeckoView {channel.capitalize()} on A-C master: {str(e)}")
-
+        for gv_channel in ("beta", "release"):
+            try:
+                _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_version, author, debug, dry_run)
+            except Exception as e:
+                print(f"{ts()} Exception while updating GeckoView {gv_channel.capitalize()} on A-C master: {str(e)}")
 
 
 #

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -148,6 +148,7 @@ def update_master(ac_repo, fenix_repo, author, debug, dry_run):
             _update_geckoview(ac_repo, fenix_repo, gv_channel, None, author, debug, dry_run)
         except Exception as e:
             print(f"{ts()} Exception while updating GeckoView {gv_channel.capitalize()} on A-C master: {str(e)}")
+        print()
 
 #
 # Update GeckoView Release and Beta in all "relevant" A-C releases.
@@ -160,6 +161,7 @@ def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
                 _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_version, author, debug, dry_run)
             except Exception as e:
                 print(f"{ts()} Exception while updating GeckoView {gv_channel.capitalize()} on A-C master: {str(e)}")
+            print()
 
 
 #

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -42,7 +42,7 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False, dry_run=False)
     if argv[1] == "android-components":
         if argv[2] == "update-geckoview-nightly" or argv[2] == "update-master":
             android_components.update_master(ac_repo, fenix_repo, author, debug, dry_run)
-        if argv[2] == "update-releases":
+        elif argv[2] == "update-releases":
             android_components.update_releases(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "update-geckoview-beta":
             android_components.update_geckoview_beta(ac_repo, fenix_repo, author, debug, dry_run)

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -42,6 +42,8 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False, dry_run=False)
     if argv[1] == "android-components":
         if argv[2] == "update-geckoview-nightly" or argv[2] == "update-master":
             android_components.update_master(ac_repo, fenix_repo, author, debug, dry_run)
+        if argv[2] == "update-releases":
+            android_components.update_releases(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "update-geckoview-beta":
             android_components.update_geckoview_beta(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "update-geckoview-release":


### PR DESCRIPTION
This patch introduces an `android-components update-releases` command that can replace `android-components update-geckoview-beta/update-geckoview-release`.

It will determine the most "relevant" Fenix releases (see #35) and then in the A-C versions that those releases use, try to update GV Beta/Release.

For GV updates we will _only_ do minor updates (84.0.1 -> 84.0.2) and _never_ major (84.x -> 85.x).