### PR TITLE
Fixes #42 - Use non-unique branch names per release branch to avoid conflicts

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -77,7 +77,7 @@ def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author,
 
         short_version = "master" if ac_major_version is None else f"{ac_major_version}"
 
-        # Create a PR branch name that is non-unique for work on this branch
+        # Create a non unique PR branch name for work on this ac release branch.
         pr_branch_name = f"relbot/ac-{short_version}"
 
         try:

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -76,7 +76,9 @@ def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author,
         #
 
         short_version = "master" if ac_major_version is None else f"{ac_major_version}"
-        pr_branch_name = f"relbot/update-geckoview/{short_version}/GV-{gv_channel.capitalize()}-{latest_gv_version}"
+
+        # Create a PR branch name that is non-unique for work on this branch
+        pr_branch_name = f"relbot/ac-{short_version}"
 
         try:
             pr_branch = ac_repo.get_branch(pr_branch_name)

--- a/src/fenix.py
+++ b/src/fenix.py
@@ -43,7 +43,7 @@ def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version,
 
     print(f"{ts()} We are going to upgrade Fenix {fenix_major_version} to Android-Components {latest_ac_version}")
 
-    # Create a PR branch name that is unique for this branch
+    # Create a non unique PR branch name for work on this fenix release branch.
     pr_branch_name = f"relbot/fenix-{fenix_major_version}"
 
     try:

--- a/src/fenix.py
+++ b/src/fenix.py
@@ -43,8 +43,8 @@ def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version,
 
     print(f"{ts()} We are going to upgrade Fenix {fenix_major_version} to Android-Components {latest_ac_version}")
 
-    # Create a PR branch name that is likely not to conflict with anything else
-    pr_branch_name = f"relbot/update-android-components/Fenix-{fenix_major_version}/AC-{latest_ac_version}"
+    # Create a PR branch name that is unique for this branch
+    pr_branch_name = f"relbot/fenix-{fenix_major_version}"
 
     try:
         pr_branch = fenix_repo.get_branch(pr_branch_name)


### PR DESCRIPTION
This patch stops using unique PR branch names and instead uses "fixed" names per release branch. This will avoid that multiple tasks will create conflicting PRs for the same release branch.