### PR TITLE
Fixes #44 - Use new style Fenix branch names

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -21,11 +21,12 @@ def _update_ac_version(fenix_repo, branch, old_ac_version, new_ac_version, autho
 # a newer android-components that can be pulled in.
 #
 
-def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version, author, debug):
+def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version, author, debug, dry_run):
     print(f"{ts()} Looking at Fenix {fenix_major_version}")
 
     # Make sure the release branch for this version exists
-    release_branch_name = f"releases/v{fenix_major_version}.0.0"
+    # TODO Temporary fix for transition between branch name conventions
+    release_branch_name = f"releases/v{fenix_major_version}.0.0" if fenix_major_version < 85 else f"releases_v{fenix_major_version}.0.0"
     release_branch = fenix_repo.get_branch(release_branch_name)
 
     print(f"{ts()} Looking at Fenix {fenix_major_version} on {release_branch_name}")
@@ -42,6 +43,10 @@ def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version,
         return
 
     print(f"{ts()} We are going to upgrade Fenix {fenix_major_version} to Android-Components {latest_ac_version}")
+
+    if dry_run:
+        print(f"{ts()} Dry-run so not continuing.")
+        return
 
     # Create a non unique PR branch name for work on this fenix release branch.
     pr_branch_name = f"relbot/fenix-{fenix_major_version}"
@@ -70,13 +75,13 @@ def update_android_components_in_fenix(ac_repo, fenix_repo, fenix_major_version,
     print(f"{ts()} Pull request at {pr.html_url}")
 
 
-def update_android_components(ac_repo, fenix_repo, author, debug):
+def update_android_components(ac_repo, fenix_repo, author, debug, dry_run):
     for fenix_version in get_recent_fenix_versions(fenix_repo):
         try:
-            update_android_components_in_fenix(ac_repo, fenix_repo, fenix_version, author, debug)
+            update_android_components_in_fenix(ac_repo, fenix_repo, fenix_version, author, debug, dry_run)
         except Exception as e:
             print(f"{ts()} Failed to update A-C in Fenix {fenix_version}: {str(e)}")
 
 
-def create_release(ac_repo, fenix_repo, author, debug):
+def create_release(ac_repo, fenix_repo, author, debug, dry_run):
     print("Creating Fenix Release")

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -65,9 +65,9 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False, dry_run=False)
     # Fenix
     elif argv[1] == "fenix":
         if argv[2] == "update-android-components":
-            fenix.update_android_components(ac_repo, fenix_repo, author, debug)
+            fenix.update_android_components(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "create-fenix-release":
-            fenix.create_release(ac_repo, fenix_repo, author, debug)
+            fenix.create_release(ac_repo, fenix_repo, author, debug, dry_run)
         else:
             print("usage: relbot fenix <update-android-components|create-release>")
             sys.exit(1)

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -262,7 +262,10 @@ def test_get_latest_ac_nightly_version():
 
 
 def test_get_fenix_release_branches(gh):
-    assert get_fenix_release_branches(gh.get_repo(f"st3fan/fenix")) == ["releases/v79.0.0", "releases/v82.0.0", "releases/v83.0.0"]
+    assert get_fenix_release_branches(gh.get_repo(f"st3fan/fenix")) == ["releases/v79.0.0",
+                                                                        "releases/v82.0.0",
+                                                                        "releases/v83.0.0",
+                                                                        "releases_v88.0.0"]
 
 
 def test_major_version_from_fenix_release_branch_name():
@@ -274,11 +277,20 @@ def test_major_version_from_fenix_release_branch_name():
         major_version_from_fenix_release_branch_name("releases/Cheese")
     with pytest.raises(Exception):
         major_version_from_fenix_release_branch_name("releases/v84.0.0-beta.1")
+    # New style branch names
+    assert major_version_from_fenix_release_branch_name("releases_v79.0.0") == 79
+    assert major_version_from_fenix_release_branch_name("releases_v83.0.0") == 83
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases_v83.1.0")
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases_Cheese")
+    with pytest.raises(Exception):
+        major_version_from_fenix_release_branch_name("releases_v84.0.0-beta.1")
 
 
 def test_get_recent_fenix_versions(gh):
-    assert get_recent_fenix_versions(gh.get_repo(f"st3fan/fenix")) == [82, 83]
+    assert get_recent_fenix_versions(gh.get_repo(f"st3fan/fenix")) == [83, 88]
 
 
 def test_get_relevant_ac_versions(gh):
-    assert get_relevant_ac_versions(gh.get_repo(f"st3fan/fenix"), gh.get_repo(f"st3fan/android-components")) == [60, 63]
+    assert get_relevant_ac_versions(gh.get_repo(f"st3fan/fenix"), gh.get_repo(f"st3fan/android-components")) == [63, 64]

--- a/src/util.py
+++ b/src/util.py
@@ -209,11 +209,11 @@ def gv_version_sort_key(a):
 
 
 def get_fenix_release_branches(repo):
-    return [branch.name for branch in repo.get_branches() if re.match(r"^releases/v\d+\.0\.0$", branch.name)]
+    return [branch.name for branch in repo.get_branches() if re.match(r"^releases[_/]v\d+\.0\.0$", branch.name)]
 
 
 def major_version_from_fenix_release_branch_name(branch_name):
-    if matches := re.match(r"^releases/v(\d+)\.0\.0$", branch_name):
+    if matches := re.match(r"^releases[_/]v(\d+)\.0\.0$", branch_name):
         return int(matches[1])
     raise Exception(f"Unexpected release branch name: {branch_name}")
 
@@ -232,7 +232,8 @@ def get_recent_fenix_versions(repo):
 def get_relevant_ac_versions(fenix_repo, ac_repo):
     releases = []
     for fenix_version in get_recent_fenix_versions(fenix_repo):
-        release_branch_name = f"releases/v{fenix_version}.0.0"
+        # TODO Temporary fix for transition between branch name conventions
+        release_branch_name = f"releases/v{fenix_version}.0.0" if fenix_version < 85 else f"releases_v{fenix_version}.0.0"
         ac_version = get_current_ac_version_in_fenix(fenix_repo, release_branch_name)
         releases.append(int(major_ac_version_from_version(ac_version)))
     return sorted(releases)


### PR DESCRIPTION
This patch makes sure we recognize both old style `releases/v84.0.0` and new style `releases_v85.0.0` branch names. It uses a fenix major version check (< 85) to determine the correct name in two places. This is code that can eventually be removed.