### PR TITLE
Fixes #40 - Use version.txt instead of .buildconfig.yml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Deprecated==1.2.10
 idna==2.10
 PyGithub==1.53
 PyJWT==1.7.1
-PyYAML==5.3.1
 requests==2.24.0
 urllib3==1.25.11
 wrapt==1.12.1

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -106,8 +106,8 @@ def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author,
         _update_gv_version(ac_repo, current_gv_version, latest_gv_version, pr_branch_name, gv_channel, author)
 
         #
-        # If we are updating a release branch then update also update .buildConfig to increment
-        # the patch version.
+        # If we are updating a release branch then update also update
+        # version.txt to increment the patch version.
         #
 
         if release_branch_name != "master":
@@ -116,7 +116,7 @@ def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author,
 
             print(f"{ts()} Create an A-C {next_ac_version} release with GV {gv_channel.capitalize()} {latest_gv_version}")
 
-            print(f"{ts()} Updating .buildConfig.yml")
+            print(f"{ts()} Updating version.txt")
             _update_ac_version(ac_repo, current_ac_version, next_ac_version, pr_branch_name, author)
 
         #

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -12,6 +12,18 @@ from util import *
 # Helpers
 #
 
+def _update_ac_buildconfig(ac_repo, old_ac_version, new_ac_version, branch, author):
+    contents = ac_repo.get_contents(".buildconfig.yml", ref=branch)
+
+    content = contents.decoded_content.decode("utf-8")
+    new_content = re.sub(r"componentsVersion: \d+\.\d+\.\d+", f"componentsVersion: {new_ac_version}", content)
+    if content == new_content:
+        print(f"{ts()} Update to .buildConfig.yml resulted in no changes: maybe the file was already up to date?")
+
+    ac_repo.update_file(contents.path, f"Set version to {new_ac_version}.", new_content,
+                     contents.sha, branch=branch, author=author)
+
+
 def _update_ac_version(ac_repo, old_ac_version, new_ac_version, branch, author):
     contents = ac_repo.get_contents("version.txt", ref=branch)
 
@@ -118,6 +130,10 @@ def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author,
 
             print(f"{ts()} Updating version.txt")
             _update_ac_version(ac_repo, current_ac_version, next_ac_version, pr_branch_name, author)
+
+            # TODO Also update buildconfig until we do not need it anymore
+            print(f"{ts()} Updating buildconfig.yml")
+            _update_ac_buildconfig(ac_repo, current_ac_version, next_ac_version, pr_branch_name, author)
 
         #
         # Create the pull request

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -12,17 +12,16 @@ from util import *
 # Helpers
 #
 
-
 def _update_ac_version(ac_repo, old_ac_version, new_ac_version, branch, author):
-    contents = ac_repo.get_contents(".buildconfig.yml", ref=branch)
-    content = contents.decoded_content.decode("utf-8")
-    new_content = content.replace(f"componentsVersion: {old_ac_version}",
-                                  f"componentsVersion: {new_ac_version}")
-    if content == new_content:
-        raise Exception("Update to .buildConfig.yml resulted in no changes: maybe the file was already up to date?")
+    contents = ac_repo.get_contents("version.txt", ref=branch)
 
-    ac_repo.update_file(contents.path, f"Set version to {new_ac_version}.", new_content,
-                     contents.sha, branch=branch, author=author)
+    content = contents.decoded_content.decode("utf-8")
+    new_content = content.replace(old_ac_version, new_ac_version)
+    if content == new_content:
+        raise Exception("Update to version.txt resulted in no changes: maybe the file was already up to date?")
+
+    ac_repo.update_file(contents.path, f"Set version.txt to {new_ac_version}.", new_content,
+                        contents.sha, branch=branch, author=author)
 
 
 def _update_gv_version(ac_repo, old_gv_version, new_gv_version, branch, channel, author):

--- a/src/util.py
+++ b/src/util.py
@@ -7,7 +7,6 @@ import datetime, re, time
 
 
 from github import Github, GithubException, InputGitAuthor
-import yaml
 import requests
 import xmltodict
 
@@ -90,9 +89,9 @@ def get_current_gv_version(repo, release_branch_name, channel):
 
 def get_current_ac_version(repo, release_branch_name):
     """Return the current ac version used on the given release branch"""
-    content_file = repo.get_contents(".buildconfig.yml", ref=release_branch_name)
-    build_config = yaml.load(content_file.decoded_content.decode('utf8'), Loader=yaml.Loader)
-    return build_config['componentsVersion']
+    content_file = repo.get_contents("version.txt", ref=release_branch_name)
+    content = content_file.decoded_content.decode('utf8')
+    return validate_ac_version(content.strip())
 
 
 def get_latest_ac_version_for_major_version(ac_repo, ac_major_version):


### PR DESCRIPTION
This patch replaces usage of `.buildconfig.yml` to `version.txt`.

The `version.txt` is now leading - we find the current version there and we always update it.

Right now we also keep `.buildconfig.yml` up to date. Because it is unclear if other tools still need it. That code can be removed at a later time. And note that Ship-It does not touch `.buildconfig.yml` actually.
