### PR TITLE
Fixes #47 - Remove unused update-geckoview-{beta,release} commands

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -167,34 +167,6 @@ def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
 
 
 #
-# Update GeckoView Beta in the currently most recent A-C release. This
-# will result in a PR to update Gecko.kt and also a version increment
-# in .buildconfig.yml
-#
-
-def update_geckoview_beta(ac_repo, fenix_repo, author, debug, dry_run):
-    try:
-        ac_major_version = discover_ac_major_version(ac_repo)
-        _update_geckoview(ac_repo, fenix_repo, "beta", ac_major_version, author, debug, dry_run)
-    except Exception as e:
-        print(f"{ts()} Exception while updating GeckoView Beta on A-C master: {str(e)}")
-
-
-#
-# Update GeckoView Release in the currently most recent A-C release. This
-# will result in a PR to update Gecko.kt and also a version increment
-# in .buildconfig.yml
-#
-
-def update_geckoview_release(ac_repo, fenix_repo, author, debug, dry_run):
-    try:
-        ac_major_version = discover_ac_major_version(ac_repo)
-        _update_geckoview(ac_repo, fenix_repo, "release", ac_major_version, author, debug, dry_run)
-    except Exception as e:
-        print(f"{ts()} Exception while updating GeckoView Release on A-C master: {str(e)}")
-
-
-#
 # Create an Android-Components release on the current release branch,
 # if it does not already exist. The logic is as follows:
 #

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -40,18 +40,14 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False, dry_run=False)
 
     # Android Components
     if argv[1] == "android-components":
-        if argv[2] == "update-geckoview-nightly" or argv[2] == "update-master":
+        if argv[2] == "update-master":
             android_components.update_master(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "update-releases":
             android_components.update_releases(ac_repo, fenix_repo, author, debug, dry_run)
-        elif argv[2] == "update-geckoview-beta":
-            android_components.update_geckoview_beta(ac_repo, fenix_repo, author, debug, dry_run)
-        elif argv[2] == "update-geckoview-release":
-            android_components.update_geckoview_release(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "create-release":
             android_components.create_release(ac_repo, fenix_repo, author, debug)
         else:
-            print("usage: relbot android-components <update-geckoview-{nighty,beta}|update-geckoview-release|create-release>")
+            print("usage: relbot android-components <update-{master,releases}|create-release>")
             sys.exit(1)
 
     # Reference Browser


### PR DESCRIPTION
This patch removes the code for `update-geckoview-beta` and `update-geckoview-release` - those commands are not covered by `update-releases`.

The workflow in android-components was already updated to not call those anymore.