### PR TITLE
Fixes #49 - Turn android-components/create-release into create-releases

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -198,41 +198,53 @@ def update_geckoview_release(ac_repo, fenix_repo, author, debug, dry_run):
 # Create an Android-Components release on the current release branch,
 # if it does not already exist. The logic is as follows:
 #
-#  - Determine the latest release branch (currently hardcoded)
-#  - Check the version by looking at .buildconfig.yaml
+#  - Determine the "relevant" release branches
+#  - Check the version by looking at version.txt
 #  - If no github release exists, create it
 #
 # This basically means the trigger for a release is a change of the
-# `componentsVersion` field in `.buildconfig.yml`.
+# version.txt file.
 #
 # This can be run periodically, manually or triggered by a change
-# on .builconfig.yml.
+# on version.txt.
 #
 # TODO Instead of looking at the latest release branch, check all
 # relevant branches - those used by live products?
 #
 
-def create_release(ac_repo, fenix_repo, author, debug):
-    ac_major_version = discover_ac_major_version(ac_repo)
+def _create_release(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run):
     release_branch_name = f"releases/{ac_major_version}.0"
     current_version = get_current_ac_version(ac_repo, release_branch_name)
     release_branch = ac_repo.get_branch(release_branch_name)
 
     if current_version.endswith(".0"):
         print(f"{ts()} Current version {current_version} is not a dot release. Exiting. ")
-        sys.exit(0)
+        return
 
     print(f"{ts()} Checking if android-components release {current_version} already exists.")
 
     releases = get_recent_ac_releases(ac_repo)
     if len(releases) == 0:
         print(f"{ts()} No releases found. Exiting. ")
-        sys.exit(0)
+        return
 
     if current_version in releases:
         print(f"{ts()} Release {current_version} already exists. Exiting. ")
-        sys.exit(0)
+        return
 
     print(f"{ts()} Creating android-components release {current_version}")
+
+    if dry_run:
+        print(f"{ts()} Dry-run so not continuing.")
+        return
+
     ac_repo.create_git_tag_and_release(f"v{current_version}", current_version,
         current_version, f"Release {current_version}", release_branch.commit.sha, "commit")
+
+def create_releases(ac_repo, fenix_repo, author, debug, dry_run):
+    for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
+        try:
+            _create_release(ac_repo, fenix_repo, ac_version, author, debug, dry_run)
+        except Exception as e:
+            print(f"{ts()} Exception while creating Android-Components release for {ac_version}: {str(e)}")
+        print()

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -48,10 +48,10 @@ def main(argv, ac_repo, rb_repo, fenix_repo, author, debug=False, dry_run=False)
             android_components.update_geckoview_beta(ac_repo, fenix_repo, author, debug, dry_run)
         elif argv[2] == "update-geckoview-release":
             android_components.update_geckoview_release(ac_repo, fenix_repo, author, debug, dry_run)
-        elif argv[2] == "create-release":
-            android_components.create_release(ac_repo, fenix_repo, author, debug)
+        elif argv[2] == "create-releases":
+            android_components.create_releases(ac_repo, fenix_repo, author, debug, dry_run)
         else:
-            print("usage: relbot android-components <update-geckoview-{nighty,beta}|update-geckoview-release|create-release>")
+            print("usage: relbot android-components <update-geckoview-{nighty,beta}|update-geckoview-release|create-releases>")
             sys.exit(1)
 
     # Reference Browser

--- a/src/util.py
+++ b/src/util.py
@@ -12,13 +12,6 @@ import requests
 import xmltodict
 
 
-AC_MAJOR_VERSION = 67 # TODO This should be discovered dynamically
-
-
-def discover_ac_major_version(repo):
-    return AC_MAJOR_VERSION # TODO This should be discovered dynamically
-
-
 def validate_ac_version(v):
     """Validate that v is in the format of 63.0.2. Returns v or raises an exception."""
     if not re.match(r"^\d+\.\d+\.\d+$", v):


### PR DESCRIPTION
> The `relbot android-components create-release` command should not just look at the hard-coded version but instead discover the "relevant" a-c versions and then check if releases need to be created.
