### PR TITLE
Support new-style GV Nightly updates

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -76,9 +76,11 @@ def _update_as_version(ac_repo, old_as_version, new_as_version, branch, author):
 
 
 #
-# Update GeckoView $gv_channel in A-C $ac_release. if ac_release is None then we
-# update master. Otherwise it should be a major release version for which a
-# release branch exists.
+# This _new version is to support the new style versioning according
+# to RFC7, which has now been deployed on A-C master. The plan is to
+# have both old and new code in relbot until Fenix 90 has a release
+# branch. At that point we can just use the new code and remove the
+# old implementation.
 #
 
 def _update_geckoview_new(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run=False):
@@ -171,26 +173,9 @@ def _update_geckoview_new(ac_repo, fenix_repo, ac_major_version, author, debug, 
                                  body=f"This (automated) patch updates GV {gv_channel.capitalize()} on master to {latest_gv_version}.",
                                  head=pr_branch_name, base=release_branch_name)
         print(f"{ts()} Pull request at {pr.html_url}")
-
-
     except Exception as e:
         # TODO Clean up the mess
         raise e
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author, debug, dry_run=False):

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -51,6 +51,18 @@ def _update_gv_version(ac_repo, old_gv_version, new_gv_version, branch, channel,
                      new_content, contents.sha, branch=branch, author=author)
 
 
+def _update_gv_version_new(ac_repo, old_gv_version, new_gv_version, branch, channel, author):
+    contents = ac_repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=branch)
+    content = contents.decoded_content.decode("utf-8")
+    new_content = content.replace(f'const val version = "{old_gv_version}"',
+                                  f'const val version = "{new_gv_version}"')
+    if content == new_content:
+        raise Exception("Update to Gecko.kt resulted in no changes: maybe the file was already up to date?")
+
+    ac_repo.update_file(contents.path, f"Update GeckoView ({channel.capitalize()}) to {new_gv_version}.",
+                     new_content, contents.sha, branch=branch, author=author)
+
+
 def _update_as_version(ac_repo, old_as_version, new_as_version, branch, author):
     contents = ac_repo.get_contents("buildSrc/src/main/java/Dependencies.kt", ref=branch)
     content = contents.decoded_content.decode("utf-8")
@@ -68,6 +80,118 @@ def _update_as_version(ac_repo, old_as_version, new_as_version, branch, author):
 # update master. Otherwise it should be a major release version for which a
 # release branch exists.
 #
+
+def _update_geckoview_new(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run=False):
+    try:
+        if ac_major_version != "master":
+            raise Exception(f"Unsupported A-C Version {ac_major_version}. This is work in progress.")
+
+        release_branch_name = "master" if ac_major_version is "master" else f"releases/{ac_major_version}.0"
+        print(f"{ts()} Updating GeckoView on A-C {ac_repo.full_name}:{release_branch_name}")
+
+        gv_channel = get_current_gv_channel(ac_repo, release_branch_name)
+        print(f"{ts()} Current GV channel is {gv_channel}")
+
+        current_gv_version = get_current_gv_version_new(ac_repo, release_branch_name)
+        print(f"{ts()} Current GV {gv_channel.capitalize()} version in A-C {ac_repo.full_name}:{release_branch_name} is {current_gv_version}")
+
+        current_gv_major_version = major_gv_version_from_version(current_gv_version)
+        latest_gv_version = get_latest_gv_version(current_gv_major_version, gv_channel)
+        print(f"{ts()} Latest GV {gv_channel.capitalize()} version available is {latest_gv_version}")
+
+        if compare_gv_versions(current_gv_version, latest_gv_version) >= 0:
+            print(f"{ts()} No newer GV {gv_channel.capitalize()} release found. Exiting.")
+            return
+
+        print(f"{ts()} We should update A-C {release_branch_name} with GV {gv_channel.capitalize()} {latest_gv_version}")
+
+        if dry_run:
+            print(f"{ts()} Dry-run so not continuing.")
+            return
+
+        #
+        # Check if the branch already exists
+        #
+
+        short_version = "master" if ac_major_version is "master" else f"{ac_major_version}"
+
+        # Create a non unique PR branch name for work on this ac release branch.
+        pr_branch_name = f"relbot/upgrade-geckoview-ac-{short_version}"
+
+        try:
+            pr_branch = ac_repo.get_branch(pr_branch_name)
+            if pr_branch:
+                print(f"{ts()} The PR branch {pr_branch_name} already exists. Exiting.")
+                return
+        except GithubException as e:
+            # TODO Only ignore a 404 here, fail on others
+            pass
+
+        #
+        # Create a new branch for this update
+        #
+
+        release_branch = ac_repo.get_branch(release_branch_name)
+        print(f"{ts()} Last commit on {release_branch_name} is {release_branch.commit.sha}")
+
+        ac_repo.create_git_ref(ref=f"refs/heads/{pr_branch_name}", sha=release_branch.commit.sha)
+        print(f"{ts()} Created branch {pr_branch_name} on {release_branch.commit.sha}")
+
+        #
+        # Update buildSrc/src/main/java/Gecko.kt
+        #
+
+        print(f"{ts()} Updating buildSrc/src/main/java/Gecko.kt")
+        _update_gv_version_new(ac_repo, current_gv_version, latest_gv_version, pr_branch_name, gv_channel, author)
+
+        #
+        # If we are updating a release branch then update also update
+        # version.txt to increment the patch version.
+        #
+
+        if release_branch_name != "master":
+            current_ac_version = get_current_ac_version(ac_repo, release_branch_name)
+            next_ac_version = get_next_ac_version(current_ac_version)
+
+            print(f"{ts()} Create an A-C {next_ac_version} release with GV {gv_channel.capitalize()} {latest_gv_version}")
+
+            print(f"{ts()} Updating version.txt")
+            _update_ac_version(ac_repo, current_ac_version, next_ac_version, pr_branch_name, author)
+
+            # TODO Also update buildconfig until we do not need it anymore
+            print(f"{ts()} Updating buildconfig.yml")
+            _update_ac_buildconfig(ac_repo, current_ac_version, next_ac_version, pr_branch_name, author)
+
+        #
+        # Create the pull request
+        #
+
+        print(f"{ts()} Creating pull request")
+        pr = ac_repo.create_pull(title=f"Update to GeckoView {gv_channel.capitalize()} {latest_gv_version} on {release_branch_name}",
+                                 body=f"This (automated) patch updates GV {gv_channel.capitalize()} on master to {latest_gv_version}.",
+                                 head=pr_branch_name, base=release_branch_name)
+        print(f"{ts()} Pull request at {pr.html_url}")
+
+
+    except Exception as e:
+        # TODO Clean up the mess
+        raise e
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 def _update_geckoview(ac_repo, fenix_repo, gv_channel, ac_major_version, author, debug, dry_run=False):
     try:
@@ -254,13 +378,12 @@ def update_master(ac_repo, fenix_repo, author, debug, dry_run):
     try:
         _update_application_services(ac_repo, fenix_repo, None, author, debug, dry_run)
     except Exception as e:
-        print(f"{ts()} Exception while updating A-S on A-C {ac_repo.name}:master: {str(e)}")
+        print(f"{ts()} Exception while updating A-S on A-C {ac_repo.full_name}:master: {str(e)}")
 
-    for gv_channel in ('nightly', 'beta', 'release'):
-        try:
-            _update_geckoview(ac_repo, fenix_repo, gv_channel, None, author, debug, dry_run)
-        except Exception as e:
-            print(f"{ts()} Exception while updating GeckoView {gv_channel.capitalize()} on A-C master: {str(e)}")
+    try:
+        _update_geckoview_new(ac_repo, fenix_repo, "master", author, debug, dry_run)
+    except Exception as e:
+        print(f"{ts()} Exception while updating GeckoView on A-C {ac_repo.full_name}:master: {str(e)}")
 
 #
 # Update GeckoView Release and Beta in all "relevant" A-C releases.

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -51,6 +51,42 @@ def test_match_gv_version():
     assert match_gv_version(GECKO_KT, "beta") == "81.0.20200910180444"
 
 
+GECKO_KT_NEW = """
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Gecko version and release channel constants used by this version of Android Components.
+ */
+object Gecko {
+    /**
+     * GeckoView Version.
+     */
+    const val version = "90.0.20210420095122"
+
+    /**
+     * GeckoView channel
+     */
+    val channel = GeckoChannel.NIGHTLY
+}
+
+/**
+ * Enum for GeckoView release channels.
+ */
+enum class GeckoChannel(
+    val artifactName: String
+) {
+    NIGHTLY("geckoview-nightly"),
+    BETA("geckoview-beta"),
+    RELEASE("geckoview")
+}
+"""
+
+def test_match_gv_version_new():
+    assert match_gv_version_new(GECKO_KT_NEW) == "90.0.20210420095122"
+
+
 def test_get_current_gv_version(gh):
     repo = gh.get_repo(f"st3fan/android-components")
     assert get_current_gv_version(repo, "releases/57.0", "beta") == "81.0.20200910180444"
@@ -60,6 +96,15 @@ def test_get_current_gv_version(gh):
 def test_get_current_gv_version_new(gh):
     repo = gh.get_repo(f"st3fan/android-components")
     assert get_current_gv_version_new(repo, "master") == "90.0.20210420095122"
+
+
+def test_match_gv_channel():
+    assert match_gv_channel(GECKO_KT_NEW) == "nightly"
+
+
+def test_get_current_gv_channel(gh):
+    repo = gh.get_repo(f"st3fan/android-components")
+    assert get_current_gv_channel(repo, "master") == "nightly"
 
 
 ANDROID_COMPONENTS_KT = """

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -53,9 +53,13 @@ def test_match_gv_version():
 
 def test_get_current_gv_version(gh):
     repo = gh.get_repo(f"st3fan/android-components")
-    assert get_current_gv_version(repo, "master", "nightly") == "88.0.20210301093612"
     assert get_current_gv_version(repo, "releases/57.0", "beta") == "81.0.20200910180444"
     assert get_current_gv_version(repo, "releases/57.0", "release") == "81.0.20201108175212"
+
+
+def test_get_current_gv_version_new(gh):
+    repo = gh.get_repo(f"st3fan/android-components")
+    assert get_current_gv_version_new(repo, "master") == "90.0.20210420095122"
 
 
 ANDROID_COMPONENTS_KT = """
@@ -98,7 +102,7 @@ def test_get_current_ac_version_in_reference_browser(gh):
 
 def test_get_current_ac_version(gh):
     repo = gh.get_repo(f"st3fan/android-components")
-    assert get_current_ac_version(repo, "releases/73.0") == "73.0.3"
+    assert get_current_ac_version(repo, "releases/73.0") == "73.0.12"
 
 
 def test_validate_gv_version_bad():
@@ -119,6 +123,23 @@ def test_validate_gv_version_bad():
 def test_validate_gv_version_good():
     assert validate_gv_version("81.0.20201012085804") == "81.0.20201012085804"
     assert validate_gv_version("123.0.20231012085804") == "123.0.20231012085804"
+
+
+def test_validate_gv_channel_good():
+    assert validate_gv_channel("nightly") == "nightly"
+    assert validate_gv_channel("beta") == "beta"
+    assert validate_gv_channel("release") == "release"
+
+
+def test_validate_gv_channel_bad():
+    with pytest.raises(Exception):
+        assert validate_gv_channel("")
+    with pytest.raises(Exception):
+        assert validate_gv_channel("Nightly")
+    with pytest.raises(Exception):
+        assert validate_gv_channel("BETA")
+    with pytest.raises(Exception):
+        assert validate_gv_channel("Something")
 
 
 def test_validate_ac_version_bad():
@@ -268,7 +289,8 @@ def test_get_fenix_release_branches(gh):
                                                                         "releases/v84.0.0",
                                                                         "releases_v85.0.0",
                                                                         "releases_v86.0.0",
-                                                                        "releases_v87.0.0"]
+                                                                        "releases_v87.0.0",
+                                                                        "releases_v88.0.0"]
 
 
 def test_major_version_from_fenix_release_branch_name():
@@ -292,8 +314,8 @@ def test_major_version_from_fenix_release_branch_name():
 
 
 def test_get_recent_fenix_versions(gh):
-    assert get_recent_fenix_versions(gh.get_repo(f"st3fan/fenix")) == [86, 87]
+    assert get_recent_fenix_versions(gh.get_repo(f"st3fan/fenix")) == [87, 88]
 
 
 def test_get_relevant_ac_versions(gh):
-    assert get_relevant_ac_versions(gh.get_repo(f"st3fan/fenix"), gh.get_repo(f"st3fan/android-components")) == [72, 73]
+    assert get_relevant_ac_versions(gh.get_repo(f"st3fan/fenix"), gh.get_repo(f"st3fan/android-components")) == [73, 74]

--- a/src/util.py
+++ b/src/util.py
@@ -30,6 +30,15 @@ def validate_gv_version(v):
         raise Exception(f"Invalid GV version {v}")
     return v
 
+
+# TODO Needs test
+def validate_gv_channel(c):
+    """Validate that c is release, production or beta"""
+    if c not in ('release', 'beta', 'nightly'):
+        raise Exception(f"Invalid GV channel {c}")
+    return c
+
+
 def major_gv_version_from_version(v):
     """Return the major version for the given GV version"""
     c = validate_gv_version(v).split(".")
@@ -73,6 +82,34 @@ def get_current_gv_version(repo, release_branch_name, channel):
         raise Exception(f"Invalid channel {channel}")
     content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
     return match_gv_version(content_file.decoded_content.decode('utf8'), channel)
+
+# TODO Needs test
+def match_gv_version_new(src):
+    """Find the GeckoView version in the contents of the given Gecko.kt file."""
+    if match := re.compile(fr'version = "([^"]*)"', re.MULTILINE).search(src):
+        return validate_gv_version(match[1])
+    raise Exception(f"Could not match the {channel}_version in Gecko.kt")
+
+
+# TODO Needs test
+def get_current_gv_version_new(repo, release_branch_name):
+    """Return the current gv version used on the given release branch"""
+    content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
+    return match_gv_version_new(content_file.decoded_content.decode('utf8'))
+
+
+# TODO Needs test
+def match_gv_channel(src):
+    """Find the GeckoView channel in the contents of the given Gecko.kt file."""
+    if match := re.compile(r'val channel = GeckoChannel.(NIGHTLY|BETA|RELEASE)', re.MULTILINE).search(src):
+        return validate_gv_channel(match[1].lower())
+    raise Exception(f"Could not match the channel in Gecko.kt")
+
+# TODO Needs test
+def get_current_gv_channel(repo, release_branch_name):
+    """Return the current gv channel used on the given release branch"""
+    content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
+    return match_gv_channel(content_file.decoded_content.decode('utf8'))
 
 
 def get_current_ac_version(repo, release_branch_name):

--- a/src/util.py
+++ b/src/util.py
@@ -31,7 +31,6 @@ def validate_gv_version(v):
     return v
 
 
-# TODO Needs test
 def validate_gv_channel(c):
     """Validate that c is release, production or beta"""
     if c not in ('release', 'beta', 'nightly'):
@@ -83,7 +82,7 @@ def get_current_gv_version(repo, release_branch_name, channel):
     content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
     return match_gv_version(content_file.decoded_content.decode('utf8'), channel)
 
-# TODO Needs test
+
 def match_gv_version_new(src):
     """Find the GeckoView version in the contents of the given Gecko.kt file."""
     if match := re.compile(fr'version = "([^"]*)"', re.MULTILINE).search(src):
@@ -91,21 +90,19 @@ def match_gv_version_new(src):
     raise Exception(f"Could not match the {channel}_version in Gecko.kt")
 
 
-# TODO Needs test
 def get_current_gv_version_new(repo, release_branch_name):
     """Return the current gv version used on the given release branch"""
     content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)
     return match_gv_version_new(content_file.decoded_content.decode('utf8'))
 
 
-# TODO Needs test
 def match_gv_channel(src):
     """Find the GeckoView channel in the contents of the given Gecko.kt file."""
     if match := re.compile(r'val channel = GeckoChannel.(NIGHTLY|BETA|RELEASE)', re.MULTILINE).search(src):
         return validate_gv_channel(match[1].lower())
     raise Exception(f"Could not match the channel in Gecko.kt")
 
-# TODO Needs test
+
 def get_current_gv_channel(repo, release_branch_name):
     """Return the current gv channel used on the given release branch"""
     content_file = repo.get_contents("buildSrc/src/main/java/Gecko.kt", ref=release_branch_name)


### PR DESCRIPTION
This patch adds support for the changes resulting from A-C RFC7. Only `master` is supported now. When the new style versioning moves to a release branch I will submit another PR to deal with those.

Right now this code includes some functions with the `_new` suffix. My plan is to keep this mix of old and new style around until we are fully switched over for Fenix 90.