### PR TITLE
Drop support for old fenix release branch names

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -40,12 +40,7 @@ def update_android_components_in_fenix(
     print(f"{ts()} Looking at Fenix {fenix_major_version}")
 
     # Make sure the release branch for this version exists
-    # TODO Temporary fix for transition between branch name conventions
-    release_branch_name = (
-        f"releases/v{fenix_major_version}.0.0"
-        if fenix_major_version < 85
-        else f"releases_v{fenix_major_version}.0.0"
-    )
+    release_branch_name = f"releases_v{fenix_major_version}.0.0"
     release_branch = fenix_repo.get_branch(release_branch_name)
 
     print(f"{ts()} Looking at Fenix {fenix_major_version} on {release_branch_name}")

--- a/src/util.py
+++ b/src/util.py
@@ -292,12 +292,7 @@ def get_recent_fenix_versions(repo):
 def get_relevant_ac_versions(fenix_repo, ac_repo):
     releases = []
     for fenix_version in get_recent_fenix_versions(fenix_repo):
-        # TODO Temporary fix for transition between branch name conventions
-        release_branch_name = (
-            f"releases/v{fenix_version}.0.0"
-            if fenix_version < 85
-            else f"releases_v{fenix_version}.0.0"
-        )
+        release_branch_name = f"releases_v{fenix_version}.0.0"
         ac_version = get_current_embedded_ac_version(fenix_repo, release_branch_name)
         releases.append(int(major_ac_version_from_version(ac_version)))
     return sorted(releases)


### PR DESCRIPTION
We switched to `releases_v{major}.0.0` with v85 a year ago.