### PR TITLE
Remove "relbot fenix create-release" function

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -113,7 +113,3 @@ def update_android_components(ac_repo, fenix_repo, author, debug, dry_run):
             )
         except Exception as e:
             print(f"{ts()} Failed to update A-C in Fenix {fenix_version}: {str(e)}")
-
-
-def create_release(ac_repo, fenix_repo, author, debug, dry_run):
-    print("Creating Fenix Release")

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -73,10 +73,8 @@ def main(
     elif argv[1] == "fenix":
         if argv[2] == "update-android-components":
             fenix.update_android_components(ac_repo, fenix_repo, author, debug, dry_run)
-        elif argv[2] == "create-fenix-release":
-            fenix.create_release(ac_repo, fenix_repo, author, debug, dry_run)
         else:
-            print("usage: relbot fenix <update-android-components|create-release>")
+            print("usage: relbot fenix <update-android-components>")
             sys.exit(1)
 
     # Focus Android


### PR DESCRIPTION
It was always a no-op, and nowadays fenix releases are created by shipit