### PR TITLE
rename ac relbranches releases_*

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -136,7 +136,9 @@ def _update_geckoview(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version == "main" else f"releases/{ac_major_version}.0"
+            "main"
+            if ac_major_version == "main"
+            else get_ac_release_branch_name(ac_major_version)
         )
         print(
             f"{ts()} Updating GeckoView on A-C {ac_repo.full_name}:{release_branch_name}"
@@ -281,7 +283,9 @@ def _update_application_services(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version is None else f"releases/{ac_major_version}.0"
+            "main"
+            if ac_major_version is None
+            else get_ac_release_branch_name(ac_major_version)
         )
         print(f"{ts()} Updating A-S on {ac_repo.full_name}:{release_branch_name}")
 
@@ -408,9 +412,7 @@ def update_main(ac_repo, fenix_repo, author, debug, dry_run):
 def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
     for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
         try:
-            _update_geckoview(
-                ac_repo, fenix_repo, ac_version, author, debug, dry_run
-            )
+            _update_geckoview(ac_repo, fenix_repo, ac_version, author, debug, dry_run)
         except Exception as e:
             print(f"{ts()} Exception while updating GeckoView on A-C {ac_version}")
 
@@ -435,7 +437,7 @@ def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
 
 
 def _create_release(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run):
-    release_branch_name = f"releases/{ac_major_version}.0"
+    release_branch_name = get_ac_release_branch_name(ac_major_version)
     current_version = get_current_ac_version(ac_repo, release_branch_name)
     release_branch = ac_repo.get_branch(release_branch_name)
 

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -360,7 +360,14 @@ def test_get_latest_glean_version_beta(gh):
 
 
 @pytest.mark.parametrize(
-    "version,branch", (("95", "releases_v95.0"), ("94", "releases/v94.0"))
+    "version,branch",
+    (
+        (
+            AC_UNDERSCORE_BRANCH_NAMES_RELEASE,
+            f"releases_v{AC_UNDERSCORE_BRANCH_NAMES_RELEASE}.0",
+        ),
+        ("94", "releases/v94.0"),
+    ),
 )
 def test_get_release_branch_name(version, branch):
     assert get_ac_release_branch_name(version) == branch

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -357,3 +357,10 @@ def test_get_latest_glean_version_release(gh):
 
 def test_get_latest_glean_version_beta(gh):
     assert get_latest_glean_version("96.0.20211228195952", "beta") == "42.1.0"
+
+
+@pytest.mark.parametrize(
+    "version,branch", (("95", "releases_v95.0"), ("94", "releases/v94.0"))
+)
+def test_get_release_branch_name(version, branch):
+    assert get_ac_release_branch_name(version) == branch

--- a/src/util.py
+++ b/src/util.py
@@ -98,8 +98,15 @@ def get_current_ac_version(repo, release_branch_name):
     return validate_ac_version(content.strip())
 
 
+def get_ac_release_branch_name(ac_major_version):
+    if ac_major_version < 95:
+        return f"releases/v{ac_major_version}.0"
+    else:
+        return f"releases_v{ac_major_version}.0"
+
+
 def get_latest_ac_version_for_major_version(ac_repo, ac_major_version):
-    return get_current_ac_version(ac_repo, f"releases/{ac_major_version}.0")
+    return get_current_ac_version(ac_repo, get_ac_release_branch_name(ac_major_version))
 
 
 MAVEN = "https://maven.mozilla.org/maven2"

--- a/src/util.py
+++ b/src/util.py
@@ -99,7 +99,7 @@ def get_current_ac_version(repo, release_branch_name):
 
 
 def get_ac_release_branch_name(ac_major_version):
-    if ac_major_version < 95:
+    if int(ac_major_version) < 95:
         return f"releases/v{ac_major_version}.0"
     else:
         return f"releases_v{ac_major_version}.0"

--- a/src/util.py
+++ b/src/util.py
@@ -12,6 +12,9 @@ import xmltodict
 import json
 
 
+AC_UNDERSCORE_BRANCH_NAMES_RELEASE = 99
+
+
 def validate_ac_version(v):
     """Validate that v is in the format of 63.0.2. Returns v or raises an exception."""
     if not re.match(r"^\d+\.\d+\.\d+$", v):
@@ -99,7 +102,7 @@ def get_current_ac_version(repo, release_branch_name):
 
 
 def get_ac_release_branch_name(ac_major_version):
-    if int(ac_major_version) < 95:
+    if int(ac_major_version) < AC_UNDERSCORE_BRANCH_NAMES_RELEASE:
         return f"releases/v{ac_major_version}.0"
     else:
         return f"releases_v{ac_major_version}.0"


### PR DESCRIPTION
Fixes #51.

- [ ] branch protections
- [ ] mergify rules
- [ ] update docs, see if we're breaking anything else with this change
- [ ] *then* merge this / roll this out.

This may mean we want to bump the cutoff version, if we miss the 95 branch point.