### PR TITLE
Allow upgrading to a newer GV major version on A-C main

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -150,7 +150,11 @@ def _update_geckoview(
             f"{ts()} Current GV {gv_channel.capitalize()} version in A-C {ac_repo.full_name}:{release_branch_name} is {current_gv_version}"
         )
 
-        current_gv_major_version = major_gv_version_from_version(current_gv_version)
+        if ac_major_version == "main":
+            # We always want to be on the latest geckoview version on the main branch
+            current_gv_major_version = None
+        else:
+            current_gv_major_version = major_gv_version_from_version(current_gv_version)
         latest_gv_version = get_latest_gv_version(current_gv_major_version, gv_channel)
         print(
             f"{ts()} Latest GV {gv_channel.capitalize()} version available is {latest_gv_version}"

--- a/src/util.py
+++ b/src/util.py
@@ -162,7 +162,7 @@ def get_latest_gv_version(gv_major_version, channel):
     lite_metadata = xmltodict.parse(r.text)
 
     versions = [v for v in metadata["metadata"]["versioning"]["versions"]["version"]
-                if v.startswith(f"{gv_major_version}.")
+                if (gv_major_version is None or v.startswith(f"{gv_major_version}."))
                 and v in lite_metadata["metadata"]["versioning"]["versions"]["version"]]
 
     if len(versions) == 0:


### PR DESCRIPTION
To streamline merge days we want relbot to bump GV to a new major
version when it becomes available instead of having to wait and do it
manually.