### PR TITLE
Let relbot bump A-C version on fenix's main branch

### DIFF
--- a/src/fenix.py
+++ b/src/fenix.py
@@ -6,10 +6,13 @@
 from util import *
 
 
-# For the current Fenix release and beta version, find out if there is
+# For the current Fenix versions, find out if there is
 # a newer android-components that can be pulled in.
 #
 def update_android_components(ac_repo, fenix_repo, author, debug, dry_run):
+    update_android_components_nightly(
+        ac_repo, fenix_repo, author, debug, "main", dry_run
+    )
     for fenix_version in get_recent_fenix_versions(fenix_repo):
         release_branch_name = f"releases_v{fenix_version}.0.0"
         try:


### PR DESCRIPTION
This aligns fenix with focus-android and means we don't need to maintain
this logic in several places.

Should go together with https://github.com/mozilla-mobile/fenix/pull/26553