### PR TITLE
Bug 1797245 - Stop using slashes in releases branch names

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -138,7 +138,7 @@ def _update_geckoview(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version == "main" else f"releases_v{ac_major_version}.0"
+            "main" if ac_major_version == "main" else f"releases_v{ac_major_version}"
         )
         print(
             f"{ts()} Updating GeckoView on A-C {ac_repo.full_name}:{release_branch_name}"
@@ -289,7 +289,7 @@ def _update_application_services(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version is None else f"releases_v{ac_major_version}.0"
+            "main" if ac_major_version is None else f"releases_v{ac_major_version}"
         )
         print(f"{ts()} Updating A-S on {ac_repo.full_name}:{release_branch_name}")
 
@@ -445,7 +445,7 @@ def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
 
 
 def _create_release(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run):
-    release_branch_name = f"releases_v{ac_major_version}.0"
+    release_branch_name = f"releases_v{ac_major_version}"
     current_version = get_current_ac_version(ac_repo, release_branch_name)
     release_branch = ac_repo.get_branch(release_branch_name)
 

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -138,7 +138,7 @@ def _update_geckoview(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version == "main" else f"releases/{ac_major_version}.0"
+            "main" if ac_major_version == "main" else f"releases_v{ac_major_version}.0"
         )
         print(
             f"{ts()} Updating GeckoView on A-C {ac_repo.full_name}:{release_branch_name}"
@@ -289,7 +289,7 @@ def _update_application_services(
 ):
     try:
         release_branch_name = (
-            "main" if ac_major_version is None else f"releases/{ac_major_version}.0"
+            "main" if ac_major_version is None else f"releases_v{ac_major_version}.0"
         )
         print(f"{ts()} Updating A-S on {ac_repo.full_name}:{release_branch_name}")
 
@@ -445,7 +445,7 @@ def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
 
 
 def _create_release(ac_repo, fenix_repo, ac_major_version, author, debug, dry_run):
-    release_branch_name = f"releases/{ac_major_version}.0"
+    release_branch_name = f"releases_v{ac_major_version}.0"
     current_version = get_current_ac_version(ac_repo, release_branch_name)
     release_branch = ac_repo.get_branch(release_branch_name)
 

--- a/src/test_util.py
+++ b/src/test_util.py
@@ -112,6 +112,7 @@ def test_get_current_embedded_ac_version(gh, repo_name, branch, expected):
 
 
 def test_get_current_ac_version(gh):
+    # TODO: Support monorepo and use a repo that is not tied to an individual
     repo = gh.get_repo(f"st3fan/android-components")
     assert get_current_ac_version(repo, "releases/73.0") == "73.0.12"
 

--- a/src/util.py
+++ b/src/util.py
@@ -99,7 +99,7 @@ def get_current_ac_version(repo, release_branch_name):
 
 
 def get_latest_ac_version_for_major_version(ac_repo, ac_major_version):
-    return get_current_ac_version(ac_repo, f"releases_v{ac_major_version}.0")
+    return get_current_ac_version(ac_repo, f"releases_v{ac_major_version}")
 
 
 MAVEN = "https://maven.mozilla.org/maven2"

--- a/src/util.py
+++ b/src/util.py
@@ -99,7 +99,7 @@ def get_current_ac_version(repo, release_branch_name):
 
 
 def get_latest_ac_version_for_major_version(ac_repo, ac_major_version):
-    return get_current_ac_version(ac_repo, f"releases/{ac_major_version}.0")
+    return get_current_ac_version(ac_repo, f"releases_v{ac_major_version}.0")
 
 
 MAVEN = "https://maven.mozilla.org/maven2"


### PR DESCRIPTION
This causes issues with the Taskcluster indexes because of the wait slashes are interpreted. This why Fenix started to use  a couple of years ago. Let's stick to it.