### PR TITLE
Bug 1800542 - part 2-4: No false positive, better logging, fix GV nightly bumps

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -399,19 +399,8 @@ def _update_application_services(
 
 
 def update_main(ac_repo, fenix_repo, author, debug, dry_run):
-    try:
-        _update_application_services(ac_repo, fenix_repo, None, author, debug, dry_run)
-    except Exception as e:
-        log.error(
-            f"Exception while updating A-S on A-C {ac_repo.full_name}:main: {str(e)}"
-        )
-
-    try:
-        _update_geckoview(ac_repo, fenix_repo, "main", author, debug, dry_run)
-    except Exception as e:
-        log.error(
-            f"Exception while updating GeckoView on A-C {ac_repo.full_name}:main: {str(e)}"
-        )
+    _update_application_services(ac_repo, fenix_repo, None, author, debug, dry_run)
+    _update_geckoview(ac_repo, fenix_repo, "main", author, debug, dry_run)
 
 
 #
@@ -421,12 +410,9 @@ def update_main(ac_repo, fenix_repo, author, debug, dry_run):
 
 def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
     for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
-        try:
-            _update_geckoview(
-                ac_repo, fenix_repo, ac_version, author, debug, dry_run
-            )
-        except Exception as e:
-            log.error(f"Exception while updating GeckoView on A-C {ac_version}")
+        _update_geckoview(
+            ac_repo, fenix_repo, ac_version, author, debug, dry_run
+        )
 
 
 #
@@ -493,9 +479,5 @@ def create_releases(ac_repo, fenix_repo, author, debug, dry_run):
         if ac_version >= 104:
             log.warning(f"Skipping Android-Components {ac_version}: releases are now created on ship-it")
             continue
-        try:
-            _create_release(ac_repo, fenix_repo, ac_version, author, debug, dry_run)
-        except Exception as e:
-            log.info(
-                f"Exception while creating Android-Components release for {ac_version}: {str(e)}"
-            )
+
+        _create_release(ac_repo, fenix_repo, ac_version, author, debug, dry_run)

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -136,12 +136,9 @@ def _update_glean_version(
 
 
 def _update_geckoview(
-    ac_repo, fenix_repo, ac_major_version, author, debug, dry_run=False
+    ac_repo, release_branch_name, ac_major_version, author, dry_run=False
 ):
     try:
-        release_branch_name = (
-            "main" if ac_major_version == "main" else f"releases_v{ac_major_version}"
-        )
         log.info(
             f"Updating GeckoView on A-C {ac_repo.full_name}:{release_branch_name}"
         )
@@ -191,7 +188,7 @@ def _update_geckoview(
         # Check if the branch already exists
         #
 
-        short_version = "main" if ac_major_version == "main" else f"{ac_major_version}"
+        short_version = "main" if release_branch_name == "main" else f"{ac_major_version}"
 
         # Create a non unique PR branch name for work on this ac release branch.
         pr_branch_name = f"relbot/upgrade-geckoview-ac-{short_version}"
@@ -289,12 +286,9 @@ def _update_geckoview(
 
 
 def _update_application_services(
-    ac_repo, fenix_repo, ac_major_version, author, debug, dry_run=False
+    ac_repo, release_branch_name, ac_major_version, author, dry_run=False
 ):
     try:
-        release_branch_name = (
-            "main" if ac_major_version is None else f"releases_v{ac_major_version}"
-        )
         log.info(f"Updating A-S on {ac_repo.full_name}:{release_branch_name}")
 
         current_as_version = get_current_as_version(ac_repo, release_branch_name, ac_major_version)
@@ -398,9 +392,12 @@ def _update_application_services(
 #
 
 
-def update_main(ac_repo, fenix_repo, author, debug, dry_run):
-    _update_application_services(ac_repo, fenix_repo, None, author, debug, dry_run)
-    _update_geckoview(ac_repo, fenix_repo, "main", author, debug, dry_run)
+def update_main(ac_repo, author, dry_run):
+    branch_name = "main"
+    current_ac_version = get_current_ac_version(ac_repo, branch_name)
+    ac_major_version = int(major_as_version_from_version(current_ac_version))
+    _update_application_services(ac_repo, branch_name, ac_major_version, author, dry_run)
+    _update_geckoview(ac_repo, branch_name, ac_major_version, author, dry_run)
 
 
 #
@@ -408,11 +405,10 @@ def update_main(ac_repo, fenix_repo, author, debug, dry_run):
 #
 
 
-def update_releases(ac_repo, fenix_repo, author, debug, dry_run):
+def update_releases(ac_repo, fenix_repo, author, dry_run):
     for ac_version in get_relevant_ac_versions(fenix_repo, ac_repo):
-        _update_geckoview(
-            ac_repo, fenix_repo, ac_version, author, debug, dry_run
-        )
+        release_branch_name = f"releases_v{ac_version}"
+        _update_geckoview(ac_repo, release_branch_name, ac_version, author, dry_run)
 
 
 #

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -395,7 +395,7 @@ def _update_application_services(
 def update_main(ac_repo, author, dry_run):
     branch_name = "main"
     current_ac_version = get_current_ac_version(ac_repo, branch_name)
-    ac_major_version = int(major_as_version_from_version(current_ac_version))
+    ac_major_version = int(major_ac_version_from_version(current_ac_version))
     _update_application_services(ac_repo, branch_name, ac_major_version, author, dry_run)
     _update_geckoview(ac_repo, branch_name, ac_major_version, author, dry_run)
 

--- a/src/fenix.py
+++ b/src/fenix.py
@@ -2,9 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-
+import logging
 from util import *
 
+log = logging.getLogger(__name__)
 
 # For the current Fenix versions, find out if there is
 # a newer android-components that can be pulled in.
@@ -34,4 +35,4 @@ def update_android_components(ac_repo, fenix_repo, author, debug, dry_run):
                 dry_run=dry_run,
             )
         except Exception as e:
-            print(f"{ts()} Failed to update A-C in Fenix {fenix_version}: {str(e)}")
+            log.error(f"Failed to update A-C in Fenix {fenix_version}: {str(e)}")

--- a/src/fenix.py
+++ b/src/fenix.py
@@ -22,17 +22,14 @@ def update_android_components(ac_repo, fenix_repo, author, debug, dry_run):
     )
     for fenix_version in get_recent_fenix_versions(fenix_repo):
         release_branch_name = f"releases_v{fenix_version}.0.0"
-        try:
-            update_android_components_release(
-                ac_repo,
-                fenix_repo,
-                target_path="",
-                target_product="fenix",
-                target_branch=release_branch_name,
-                major_version= fenix_version,
-                author=author,
-                debug=debug,
-                dry_run=dry_run,
-            )
-        except Exception as e:
-            log.error(f"Failed to update A-C in Fenix {fenix_version}: {str(e)}")
+        update_android_components_release(
+            ac_repo,
+            fenix_repo,
+            target_path="",
+            target_product="fenix",
+            target_branch=release_branch_name,
+            major_version= fenix_version,
+            author=author,
+            debug=debug,
+            dry_run=dry_run,
+        )

--- a/src/focus_android.py
+++ b/src/focus_android.py
@@ -43,17 +43,14 @@ def update_android_components_in_focus(ac_repo, focus_repo, author, debug, dry_r
     )
     for version in get_recent_focus_versions(focus_repo):
         release_branch_name = f"releases_v{version}.0"
-        try:
-            update_android_components_release(
-                ac_repo,
-                focus_repo,
-                target_path="focus-android/",
-                target_product="focus",
-                target_branch=release_branch_name,
-                major_version=version,
-                author=author,
-                debug=debug,
-                dry_run=dry_run,
-            )
-        except Exception as e:
-            log.error(f"Failed to update A-C in focus-android {version}: {str(e)}")
+        update_android_components_release(
+            ac_repo,
+            focus_repo,
+            target_path="focus-android/",
+            target_product="focus",
+            target_branch=release_branch_name,
+            major_version=version,
+            author=author,
+            debug=debug,
+            dry_run=dry_run,
+        )

--- a/src/focus_android.py
+++ b/src/focus_android.py
@@ -2,10 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import logging
 import re
 from util import *
 
-
+log = logging.getLogger(__name__)
 RELBRANCH_RE = re.compile(r"^releases_v(\d+)\.0$")
 
 
@@ -55,4 +56,4 @@ def update_android_components_in_focus(ac_repo, focus_repo, author, debug, dry_r
                 dry_run=dry_run,
             )
         except Exception as e:
-            print(f"{ts()} Failed to update A-C in focus-android {version}: {str(e)}")
+            log.error(f"Failed to update A-C in focus-android {version}: {str(e)}")

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -22,10 +22,15 @@
 
 
 import os, sys
+import logging
 
 from github import Github, InputGitAuthor, enable_console_debug_logging
 
 import android_components, fenix, focus_android, reference_browser
+
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)s - %(name)s.%(funcName)s:%(lineno)s - %(levelname)s - %(message)s", level=logging.INFO)
 
 
 DEFAULT_ORGANIZATION = "st3fan"
@@ -100,12 +105,12 @@ if __name__ == "__main__":
 
     github_access_token = os.getenv("GITHUB_TOKEN")
     if not github_access_token:
-        print("No GITHUB_TOKEN set. Exiting.")
+        log.error("No GITHUB_TOKEN set. Exiting.")
         sys.exit(1)
 
     github = Github(github_access_token)
     if github.get_user() is None:
-        print("Could not get authenticated user. Exiting.")
+        log.error("Could not get authenticated user. Exiting.")
         sys.exit(1)
 
     dry_run = os.getenv("DRY_RUN") == "True"
@@ -123,7 +128,7 @@ if __name__ == "__main__":
     author_email = os.getenv("AUTHOR_EMAIL") or DEFAULT_AUTHOR_EMAIL
     author = InputGitAuthor(author_name, author_email)
 
-    print(
+    log.info(
         f"This is relbot working on https://github.com/{organization} as {author_email} / {author_name}"
     )
 

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -49,11 +49,9 @@ def main(
     # Android Components
     if argv[1] == "android-components":
         if argv[2] == "update-main":
-            android_components.update_main(ac_repo, fenix_repo, author, debug, dry_run)
+            android_components.update_main(ac_repo, author, dry_run)
         elif argv[2] == "update-releases":
-            android_components.update_releases(
-                ac_repo, fenix_repo, author, debug, dry_run
-            )
+            android_components.update_releases(ac_repo, fenix_repo, author, dry_run)
         elif argv[2] == "create-releases" or argv[2] == "create-release":
             android_components.create_releases(
                 ac_repo, fenix_repo, author, debug, dry_run

--- a/src/util.py
+++ b/src/util.py
@@ -115,7 +115,9 @@ def get_current_ac_version(repo, release_branch_name):
     """Return the current ac version used on the given release branch"""
     content_file = repo.get_contents("version.txt", ref=release_branch_name)
     content = content_file.decoded_content.decode("utf8")
-    return validate_ac_version(content.strip())
+    ac_version = validate_ac_version(content.strip())
+    log.info(f"Fetched A-C version {ac_version} from {repo.full_name}")
+    return ac_version
 
 
 def get_latest_ac_version_for_major_version(ac_repo, ac_major_version):


### PR DESCRIPTION
Follows up:
 * https://github.com/mozilla-mobile/relbot/pull/92
 * https://github.com/mozilla-mobile/relbot/pull/93

@rvandermeulen pointed we busted[1] GeckoView nightly bumps even after https://github.com/mozilla-mobile/relbot/pull/93:

```
2022-11-18 14:49:01.925739 Exception while updating A-S on A-C mozilla-mobile/firefox-android:main: '>=' not supported between instances of 'NoneType' and 'int'
2022-11-18 14:49:01.925746 Updating GeckoView on A-C mozilla-mobile/firefox-android:main
2022-11-18 14:49:01.925753 Exception while updating GeckoView on A-C mozilla-mobile/firefox-android:main: '>=' not supported between instances of 'str' and 'int'
```

There are a few things wrong in these logs:
 1. These logs aren't structured. We don't immediately see what is a regular message, a warning, or a breaking error. 
 2. The exception message isn't helpful. We don't know what stacktrace caused this.
 3. We shouldn't mark this job as green when there are 2 breaking errors in it.
 4. `ac_major_version` is sometimes and `int`, `None`, or a `str`. Let's stick to a single type: `int`. 

This PR fixes these 4 issues. I recommend reviewing it commit by commit for the sake of clarity.

[1] https://github.com/mozilla-mobile/firefox-android/actions/runs/3497851665/jobs/5857461338