### PR TITLE
Bug 1801606 - pre-commit.ci tweaks now that it's enabled

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/.pre-commit-config.yaml @mozilla-mobile/releng

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 ---
+ci:
+    skip:
+    - hadolint
+    - shellcheck
+    - shfmt
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:


### PR DESCRIPTION
We actually have a few failures there[1]:

<img width="743" alt="Screenshot 2022-12-16 at 18 56 22" src="https://user-images.githubusercontent.com/5907366/208159710-671e5e96-1f68-4d55-bc4b-757d4cead0ad.png">

The codeowner change was suggested by :hwine[2]


[1] https://results.pre-commit.ci/run/github/308480707/1671202365._MbatjTVRO26XDA-m03clA
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1801606#c5