### PR TITLE
android-components: fix check for whether we care about the GV major version

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -178,7 +178,7 @@ def _update_geckoview(
             f"{ac_repo.full_name}:{release_branch_name} is {current_gv_version}"
         )
 
-        if ac_major_version == "main":
+        if release_branch_name == "main":
             # We always want to be on the latest geckoview version on the main branch
             current_gv_major_version = None
         else:

--- a/src/android_components.py
+++ b/src/android_components.py
@@ -418,4 +418,6 @@ def update_main(ac_repo, author, dry_run):
 def update_releases(firefox_repo, author, dry_run):
     for ac_version in get_recent_fenix_versions(firefox_repo):
         release_branch_name = f"releases_v{ac_version}"
-        _update_geckoview(firefox_repo, release_branch_name, ac_version, author, dry_run)
+        _update_geckoview(
+            firefox_repo, release_branch_name, ac_version, author, dry_run
+        )

--- a/src/relbot.py
+++ b/src/relbot.py
@@ -43,9 +43,7 @@ DEFAULT_AUTHOR_EMAIL = "sebastian@mozilla.com"
 USAGE = "usage: relbot <android-components|reference-browser> command..."  # noqa E501
 
 
-def main(
-    argv, firefox_repo, rb_repo, author, debug=False, dry_run=False
-):
+def main(argv, firefox_repo, rb_repo, author, debug=False, dry_run=False):
     if len(argv) < 2:
         print(USAGE)
         sys.exit(1)

--- a/src/util.py
+++ b/src/util.py
@@ -232,7 +232,7 @@ def ac_version_from_tag(tag):
     """Return the AC version from a release tag. Like v63.0.2 returns 63.0.2."""
     if not tag.startswith("components-v"):
         return
-    version = tag[len("components-v"):]
+    version = tag[len("components-v") :]
     MobileVersion.parse(version)
     return version
 
@@ -241,7 +241,11 @@ def get_recent_ac_releases(repo):
     releases = repo.get_releases()
     if releases.totalCount == 0:
         return []
-    return [ac_version_from_tag(release.tag_name) for release in releases[:50] if ac_version_from_tag(release.tag_name)]
+    return [
+        ac_version_from_tag(release.tag_name)
+        for release in releases[:50]
+        if ac_version_from_tag(release.tag_name)
+    ]
 
 
 def compare_gv_versions(a, b):


### PR DESCRIPTION
I messed this up in #85 so we didn't actually bump GV automatically on merge day.

Fixes #102