### PR TITLE
Bug 1862794 - Use function calls instead of const val for version and channel fields in Gecko object

### DIFF
--- a/src/android_components.py
+++ b/src/android_components.py
@@ -92,6 +92,11 @@ def _update_gv_version(
         f'const val version = "{old_gv_version}"',
         f'const val version = "{new_gv_version}"',
     )
+    new_content = new_content.replace(
+        f'fun version() = "{old_gv_version}"',
+        f'fun version() = "{new_gv_version}"',
+    )
+
     if content == new_content:
         raise Exception(
             "Update to Gecko.kt resulted in no changes: "

--- a/src/util.py
+++ b/src/util.py
@@ -74,7 +74,7 @@ def get_current_embedded_ac_version(repo, release_branch_name, target_path=""):
 
 def match_gv_version(src):
     """Find the GeckoView version in the contents of the given Gecko.kt file."""
-    if match := re.compile(r'version = "([^"]*)"', re.MULTILINE).search(src):
+    if match := re.compile(r'version\(?\)? = "([^"]*)"', re.MULTILINE).search(src):
         return validate_gv_version(match[1])
     raise Exception("Could not match the version in Gecko.kt")
 
@@ -90,7 +90,7 @@ def get_current_gv_version(ac_repo, release_branch_name, ac_major_version):
 def match_gv_channel(src):
     """Find the GeckoView channel in the contents of the given Gecko.kt file."""
     if match := re.compile(
-        r"val channel = GeckoChannel.(NIGHTLY|BETA|RELEASE)", re.MULTILINE
+        r"channel\(?\)? = GeckoChannel.(NIGHTLY|BETA|RELEASE)", re.MULTILINE
     ).search(src):
         return validate_gv_channel(match[1].lower())
     raise Exception("Could not match the channel in Gecko.kt")


### PR DESCRIPTION
Changes here are needed to https://github.com/mozilla-mobile/firefox-android/pull/4346